### PR TITLE
Allow the executor to save data to the commit record.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 cache: pip
 matrix:
     include:
+      - python: 3.7
+        env: TEST_TYPE="pre-commit"
       # Not working with some of the annotation syntax
       # - python: 3.5
       #   env: TEST_TYPE="pytest"
@@ -9,8 +11,8 @@ matrix:
         env: TEST_TYPE="pytest"
       - python: 3.7
         env: TEST_TYPE="pytest"
-      - python: 3.7
-        env: TEST_TYPE="pre-commit"
+      - python: 3.8
+        env: TEST_TYPE="pytest"
 install:
   - pip install --upgrade pip wheel setuptools
   - |

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Success!
 Or to skip validation:
 
 ```console
-$ jcache commit-nbs --no-validate tests/notebooks/*
+$ jcache commit-nbs --no-validate tests/notebooks/*.ipynb
 Committing: /Users/cjs14/GitHub/sandbox/tests/notebooks/basic.ipynb
 Committing: /Users/cjs14/GitHub/sandbox/tests/notebooks/basic_failing.ipynb
 Committing: /Users/cjs14/GitHub/sandbox/tests/notebooks/basic_unrun.ipynb
@@ -183,7 +183,7 @@ i.e. no physical copying takes place until execution time.
 If you stage some notebooks for execution, then you can list them to see which have existing records in the cache (by hash) and which will require execution:
 
 ```console
-$ jcache stage-nbs tests/notebooks/*
+$ jcache stage-nbs tests/notebooks/*.ipynb
 Staging: /Users/cjs14/GitHub/sandbox/tests/notebooks/basic.ipynb
 Staging: /Users/cjs14/GitHub/sandbox/tests/notebooks/basic_failing.ipynb
 Staging: /Users/cjs14/GitHub/sandbox/tests/notebooks/basic_unrun.ipynb
@@ -213,7 +213,7 @@ Finished!
 ```
 
 Successfully executed notebooks will be committed to the cache,
-along with any 'artefacts' created by the execution, that are inside the notebook folder.
+along with any 'artefacts' created by the execution, that are inside the notebook folder, and data supplied by the executor.
 
 ```console
 $ jcache list-staged
@@ -223,6 +223,17 @@ $ jcache list-staged
    4  tests/notebooks/complex_outputs.ipynb  2020-02-23 20:48            4
    3  tests/notebooks/basic_unrun.ipynb      2020-02-23 20:48            6
    2  tests/notebooks/basic_failing.ipynb    2020-02-23 20:48            2
+```
+
+```console
+jcache show-commit 5
+PK: 1
+URI: /Users/cjs14/GitHub/jupyter-cache/tests/notebooks/basic.ipynb
+Created: 2020-02-25 19:21
+Accessed: 2020-02-25 19:21
+Hashkey: 818f3412b998fcf4fe9ca3cca11a3fc3
+Data:
+  execution_seconds: 1.4187269599999999
 ```
 
 Once executed you may leave staged notebooks, for later re-execution, or remove them:

--- a/jupyter_cache/cli/commands/cmd_cache.py
+++ b/jupyter_cache/cli/commands/cmd_cache.py
@@ -90,12 +90,15 @@ def show_commit(cache_path, pk):
     click.echo(yaml.safe_dump(data, sort_keys=False), nl=False)
     with db.commit_artefacts_temppath(pk) as folder:
         paths = [str(p.relative_to(folder)) for p in folder.glob("**/*") if p.is_file()]
-    if not paths:
+    if not (paths or record.data):
         click.echo("")
         return
-    click.echo(f"Artifacts:")
-    for path in paths:
-        click.echo(f"- {path}")
+    if paths:
+        click.echo(f"Artifacts:")
+        for path in paths:
+            click.echo(f"- {path}")
+    if record.data:
+        click.echo(yaml.safe_dump({"Data": record.data}))
 
 
 @jcache.command("cat-artifact")

--- a/jupyter_cache/utils.py
+++ b/jupyter_cache/utils.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import time
 from typing import List, Union
 
 
@@ -29,3 +30,33 @@ def to_relative_paths(
             raise IOError(f"Path '{path}' is not in folder '{folder}''")
         rel_paths.append(rel_path)
     return rel_paths
+
+
+class Timer:
+    """Context manager for timing runtime."""
+
+    def __init__(self):
+        self._last_time = time.perf_counter()
+        self._split_time = 0
+
+    @property
+    def last_split(self):
+        return self._split_time
+
+    def reset(self):
+        """Reset timer."""
+        self._last_time = time.perf_counter()
+        self._split_time = 0
+
+    def split(self):
+        """Record a split time."""
+        self._split_time = time.perf_counter() - self._last_time
+
+    def __enter__(self):
+        """Reset timer."""
+        self.reset()
+        return self
+
+    def __exit__(self, *exc_info):
+        """Record a split time."""
+        self.split()

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     python_requires=">=3.6",
-    install_requires=["nbformat", "nbdime", "nbconvert", "sqlalchemy"],
+    install_requires=["attrs", "nbformat", "nbdime", "nbconvert", "sqlalchemy"],
     extras_require={
         "cli": ["click", "click-log", "tabulate", "pyyaml"],
         "code_style": ["flake8<3.8.0,>=3.7.0", "black", "pre-commit==1.17.0"],

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -162,13 +162,15 @@ def test_execution(tmp_path):
         os.path.join(NB_PATH, "external_output.ipynb"),
     ]
     assert len(db.list_commit_records()) == 2
-    assert db.get_commit_bundle(1).nb.cells[0] == {
+    bundle = db.get_commit_bundle(1)
+    assert bundle.nb.cells[0] == {
         "cell_type": "code",
         "execution_count": 1,
         "metadata": {},
         "outputs": [{"name": "stdout", "output_type": "stream", "text": "1\n"}],
         "source": "a=1\nprint(a)",
     }
+    assert "execution_seconds" in bundle.commit.data
     with db.commit_artefacts_temppath(2) as path:
         paths = [str(p.relative_to(path)) for p in path.glob("**/*") if p.is_file()]
         assert paths == ["artifact.txt"]


### PR DESCRIPTION
This PR allows the executor to store arbitrary (JSONable) data in the commit record.
For example, the basic executor now stores the execution time for a notebook:

```console
$ jcache stage-nbs tests/notebooks/basic.ipynb 
Cache path: /Users/cjs14/GitHub/jupyter-cache/.jupyter_cache
The cache does not yet exist, do you want to create it? [y/N]: y
Staging: /Users/cjs14/GitHub/jupyter-cache/tests/notebooks/basic.ipynb
Success!

$ jcache execute --entry-point basic
Executing: /Users/cjs14/GitHub/jupyter-cache/tests/notebooks/basic.ipynb
Success: /Users/cjs14/GitHub/jupyter-cache/tests/notebooks/basic.ipynb
Finished!

$ jcache show-commit 1
PK: 1
URI: /Users/cjs14/GitHub/jupyter-cache/tests/notebooks/basic.ipynb
Created: 2020-02-25 19:21
Accessed: 2020-02-25 19:21
Hashkey: 818f3412b998fcf4fe9ca3cca11a3fc3
Data:
  execution_seconds: 1.4187269599999999
```

also fixes #2

may be of interest to @choldgraf @akhmerov @mmcky 