### PR TITLE
Rename `commit` -> `cache`

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,72 +55,72 @@ Options:
   -h, --help        Show this message and exit.
 
 Commands:
-  cat-artifact    Print the contents of a commit artefact.
-  clear           Clear the cache completely.
-  commit-limit    Change the commit limit of the cache.
-  commit-nb       Commit a notebook that has already been executed.
-  commit-nbs      Commit notebook(s) that have already been executed.
-  diff-nb         Print a diff of a notebook to one stored in the cache.
-  execute         Execute outdated notebooks.
-  list-commits    List committed notebook records in the cache.
-  list-staged     List notebooks staged for possible execution.
-  remove-commits  Remove notebook commit(s) from the cache.
-  show-commit     Show details of a committed notebook in the cache.
-  show-staged     Show details of a staged notebook.
-  stage-nb        Commit a notebook, with possible assets.
-  stage-nbs       Stage notebook(s) for execution.
-  unstage-nbs     Unstage notebook(s) for execution.
+  cache-limit    Change the maximum number of notebooks stored in the cache.
+  cache-nb       Cache a notebook that has already been executed.
+  cache-nbs      Cache notebook(s) that have already been executed.
+  cat-artifact   Print the contents of a cached artefact.
+  clear          Clear the cache completely.
+  diff-nb        Print a diff of a notebook to one stored in the cache.
+  execute        Execute outdated notebooks.
+  list-cached    List cached notebook records in the cache.
+  list-staged    List notebooks staged for possible execution.
+  remove-cached  Remove notebooks stored in the cache.
+  show-cached    Show details of a cached notebook in the cache.
+  show-staged    Show details of a staged notebook.
+  stage-nb       Cache a notebook, with possible assets.
+  stage-nbs      Stage notebook(s) for execution.
+  unstage-nbs    Unstage notebook(s) for execution.
 ```
 
-### Commit Executed Notebooks
+### Caching Executed Notebooks
 
-You can commit notebooks straight into the cache. When committing, a check will be made that the notebooks look to have been executed correctly, i.e. the cell execution counts go sequentially up from 1.
+You can cache notebooks straight into the cache. When caching, a check will be made that the notebooks look to have been executed correctly, i.e. the cell execution counts go sequentially up from 1.
 
 ```console
-$ jcache commit-nbs tests/notebooks/basic.ipynb
+$ jcache cache-nbs tests/notebooks/basic.ipynb
 Cache path: /Users/cjs14/GitHub/sandbox/.jupyter_cache
 The cache does not yet exist, do you want to create it? [y/N]: y
-Committing: /Users/cjs14/GitHub/sandbox/tests/notebooks/basic.ipynb
+Caching: /Users/cjs14/GitHub/sandbox/tests/notebooks/basic.ipynb
 Validity Error: Expected cell 1 to have execution_count 1 not 2
-The notebook may not have been executed, continue committing? [y/N]: y
+The notebook may not have been executed, continue caching? [y/N]: y
 Success!
 ```
 
 Or to skip validation:
 
 ```console
-$ jcache commit-nbs --no-validate tests/notebooks/*.ipynb
-Committing: /Users/cjs14/GitHub/sandbox/tests/notebooks/basic.ipynb
-Committing: /Users/cjs14/GitHub/sandbox/tests/notebooks/basic_failing.ipynb
-Committing: /Users/cjs14/GitHub/sandbox/tests/notebooks/basic_unrun.ipynb
-Committing: /Users/cjs14/GitHub/sandbox/tests/notebooks/complex_outputs.ipynb
+$ jcache cache-nbs --no-validate tests/notebooks/*.ipynb
+Caching: /Users/cjs14/GitHub/sandbox/tests/notebooks/basic.ipynb
+Caching: /Users/cjs14/GitHub/sandbox/tests/notebooks/basic_failing.ipynb
+Caching: /Users/cjs14/GitHub/sandbox/tests/notebooks/basic_unrun.ipynb
+Caching: /Users/cjs14/GitHub/sandbox/tests/notebooks/complex_outputs.ipynb
 Success!
 ```
 
-Once you've committed some notebooks, you can look at the 'commit records' for what has been cached.
+Once you've cached some notebooks, you can look at the 'cache records' for what has been cached.
 
-Each notebook is hashed (code cells and kernel spec only), which is used to compare against 'staged' notebooks. Multiple hashes for the same URI can be added (the URI is just there for inspetion) and the size of the cache is limited (current default 1000) so that, at this size, the last accessed records begin to be deleted. You can remove cached records by the Primary Key (PK).
+Each notebook is hashed (code cells and kernel spec only), which is used to compare against 'staged' notebooks. Multiple hashes for the same URI can be added (the URI is just there for inspetion) and the size of the cache is limited (current default 1000) so that, at this size, the last accessed records begin to be deleted. You can remove cached records by their ID.
 
 ```console
-$ jcache list-commits --hashkeys
-  PK  URI                    Created           Accessed          Hashkey
+$ jcache list-cached --hashkeys
+  ID  URI                    Created           Accessed          Hashkey
 ----  ---------------------  ----------------  ----------------  --------------------------------
    4  complex_outputs.ipynb  2020-02-23 20:33  2020-02-23 20:33  800c4a057730a55a384cfe579e3850aa
    3  basic_unrun.ipynb      2020-02-23 20:33  2020-02-23 20:33  818f3412b998fcf4fe9ca3cca11a3fc3
    2  basic_failing.ipynb    2020-02-23 20:33  2020-02-23 20:33  72859c2bf1e12f35f30ef131f0bef320
 ```
 
-You can also commit with artefacts (external outputs of the notebook execution).
+You can also cache notebooks with artefacts (external outputs of the notebook execution).
 
 ```console
-$ jcache commit-nb -nb tests/notebooks/basic.ipynb tests/notebooks/artifact_folder/artifact.txt
-Committing: /Users/cjs14/GitHub/jupyter-cache/tests/notebooks/basic.ipynb
+$ jcache cache-nb -nb tests/notebooks/basic.ipynb tests/notebooks/artifact_folder/artifact.txt
+Caching: /Users/cjs14/GitHub/jupyter-cache/tests/notebooks/basic.ipynb
 Success!
 ```
 
 ```console
-$ jcache show-commit 1
-PK: 1
+$ jcache show-cached 1
+ID: 1
 URI: /Users/cjs14/GitHub/jupyter-cache/tests/notebooks/basic.ipynb
 Created: 2020-02-24 14:58
 Accessed: 2020-02-24 14:58
@@ -138,23 +138,23 @@ An artifact
 These must be 'upstream' of the notebook folder:
 
 ```console
-$ jcache commit-nb -nb tests/notebooks/basic.ipynb tests/test_db.py
-Committing: /Users/cjs14/GitHub/jupyter-cache/tests/notebooks/basic.ipynb
+$ jcache cache-nb -nb tests/notebooks/basic.ipynb tests/test_db.py
+Caching: /Users/cjs14/GitHub/jupyter-cache/tests/notebooks/basic.ipynb
 Artifact Error: Path '/Users/cjs14/GitHub/jupyter-cache/tests/test_db.py' is not in folder '/Users/cjs14/GitHub/jupyter-cache/tests/notebooks''
 ```
 
 ```console
-$ jcache remove-commits 3
-Removing PK = 3
+$ jcache remove-cached 3
+Removing Cache ID = 3
 Success!
 ```
 
-You can also diff any of the commit records with any (external) notebook:
+You can also diff any of the cached notebooks with any (external) notebook:
 
 ```console
 $ jcache diff-nb 2 tests/notebooks/basic.ipynb
 nbdiff
---- committed pk=2
+--- cached pk=2
 +++ other: /Users/cjs14/GitHub/sandbox/tests/notebooks/basic.ipynb
 ## inserted before nb/cells/1:
 +  code cell:
@@ -193,7 +193,7 @@ Success!
 
 ```console
 $ jcache list-staged
-  PK  URI                                    Created             Commit Pk
+  ID  URI                                    Created              Cache ID
 ----  -------------------------------------  ----------------  -----------
    4  tests/notebooks/complex_outputs.ipynb  2020-02-23 20:48            4
    3  tests/notebooks/basic_unrun.ipynb      2020-02-23 20:48
@@ -212,12 +212,12 @@ Success: /Users/cjs14/GitHub/sandbox/tests/notebooks/basic_unrun.ipynb
 Finished!
 ```
 
-Successfully executed notebooks will be committed to the cache,
+Successfully executed notebooks will be cached to the cache,
 along with any 'artefacts' created by the execution, that are inside the notebook folder, and data supplied by the executor.
 
 ```console
 $ jcache list-staged
-  PK  URI                                    Created             Commit Pk
+  ID  URI                                    Created             Commit ID
 ----  -------------------------------------  ----------------  -----------
    5  tests/notebooks/basic.ipynb            2020-02-23 20:57            5
    4  tests/notebooks/complex_outputs.ipynb  2020-02-23 20:48            4
@@ -226,8 +226,8 @@ $ jcache list-staged
 ```
 
 ```console
-jcache show-commit 5
-PK: 1
+jcache show-cached 5
+ID: 1
 URI: /Users/cjs14/GitHub/jupyter-cache/tests/notebooks/basic.ipynb
 Created: 2020-02-25 19:21
 Accessed: 2020-02-25 19:21
@@ -255,14 +255,14 @@ Success!
 
 ```console
 $ jcache list-staged
-  PK  URI                          Created             Assets
+  ID  URI                          Created             Assets
 ----  ---------------------------  ----------------  --------
    1  tests/notebooks/basic.ipynb  2020-02-25 10:01         1
 ```
 
 ```console
 $ jcache show-staged 1
-PK: 1
+ID: 1
 URI: /Users/cjs14/GitHub/jupyter-cache/tests/notebooks/basic.ipynb
 Created: 2020-02-25 10:01
 Assets:

--- a/jupyter_cache/cache/__init__.py
+++ b/jupyter_cache/cache/__init__.py
@@ -1,1 +1,1 @@
-from .main import JupyterCacheBase, DEFAULT_COMMIT_LIMIT  # noqa: F401
+from .main import JupyterCacheBase, DEFAULT_CACHE_LIMIT  # noqa: F401

--- a/jupyter_cache/cli/arguments.py
+++ b/jupyter_cache/cli/arguments.py
@@ -31,6 +31,6 @@ ASSET_PATHS = click.argument(
 )
 
 
-PK = click.argument("pk", metavar="PK", type=int)
+PK = click.argument("pk", metavar="ID", type=int)
 
-PKS = click.argument("pks", metavar="PKs", nargs=-1, type=int)
+PKS = click.argument("pks", metavar="IDs", nargs=-1, type=int)

--- a/jupyter_cache/cli/options.py
+++ b/jupyter_cache/cli/options.py
@@ -94,7 +94,7 @@ VALIDATE_NB = click.option(
 )
 
 
-OVERWRITE_COMMIT = click.option(
+OVERWRITE_CACHED = click.option(
     "--overwrite/--no-overwrite",
     default=True,
     show_default=True,

--- a/jupyter_cache/executors/base.py
+++ b/jupyter_cache/executors/base.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 from jupyter_cache.base import JupyterCacheAbstract
 
 # TODO abstact
-from jupyter_cache.cache.db import NbCommitRecord
+from jupyter_cache.cache.db import NbCacheRecord
 
 ENTRY_POINT_GROUP = "jupyter_executors"
 
@@ -33,7 +33,7 @@ class JupyterExecutorAbstract(ABC):
         return self._logger
 
     @abstractmethod
-    def run(self, uri_filter: Optional[List[str]] = None) -> List[NbCommitRecord]:
+    def run(self, uri_filter: Optional[List[str]] = None) -> List[NbCacheRecord]:
         """Run execution, stage successfully executed notebooks and return their URIs
 
         Parameters

--- a/jupyter_cache/executors/basic.py
+++ b/jupyter_cache/executors/basic.py
@@ -62,9 +62,9 @@ class JupyterExecutorBasic(JupyterExecutorAbstract):
                     data={"execution_seconds": timer.last_split},
                 )
                 try:
-                    self.cache.commit_notebook_bundle(final_bundle, overwrite=True)
+                    self.cache.cache_notebook_bundle(final_bundle, overwrite=True)
                 except Exception:
-                    self.logger.error("Failed Commit: {}".format(uri), exc_info=True)
+                    self.logger.error("Failed Caching: {}".format(uri), exc_info=True)
                     continue
 
                 self.logger.info("Success: {}".format(uri))
@@ -76,7 +76,7 @@ class JupyterExecutorBasic(JupyterExecutorAbstract):
         # TODO it would also be ideal to tag all notebooks
         # that were executed at the same time (just part of `data` or separate column?).
         # TODO maybe the status of success/failure could be stored on
-        # the stage record (commit_status=Enum('OK', 'FAILED', 'MISSING'))
+        # the stage record (cache_status=Enum('OK', 'FAILED', 'MISSING'))
         # also failed notebooks could be stored in the cache, which would be
         # accessed by stage pk (and would be deleted when removing the stage record)
         # see: https://python.quantecon.org/status.html

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -14,21 +14,21 @@ NB_PATH = os.path.join(os.path.realpath(os.path.dirname(__file__)), "notebooks")
 def test_basic_workflow(tmp_path):
     cache = JupyterCacheBase(str(tmp_path))
     with pytest.raises(NbValidityError):
-        cache.commit_notebook_file(path=os.path.join(NB_PATH, "basic.ipynb"))
-    cache.commit_notebook_file(
+        cache.cache_notebook_file(path=os.path.join(NB_PATH, "basic.ipynb"))
+    cache.cache_notebook_file(
         path=os.path.join(NB_PATH, "basic.ipynb"),
         uri="basic.ipynb",
         check_validity=False,
     )
-    assert cache.list_commit_records()[0].uri == "basic.ipynb"
-    pk = cache.match_commit_file(path=os.path.join(NB_PATH, "basic.ipynb")).pk
-    nb_bundle = cache.get_commit_bundle(pk)
+    assert cache.list_cache_records()[0].uri == "basic.ipynb"
+    pk = cache.match_cache_file(path=os.path.join(NB_PATH, "basic.ipynb")).pk
+    nb_bundle = cache.get_cache_bundle(pk)
     assert nb_bundle.nb.metadata["kernelspec"] == {
         "display_name": "Python 3",
         "language": "python",
         "name": "python3",
     }
-    assert set(nb_bundle.commit.to_dict().keys()) == {
+    assert set(nb_bundle.record.to_dict().keys()) == {
         "pk",
         "hashkey",
         "uri",
@@ -37,14 +37,14 @@ def test_basic_workflow(tmp_path):
         "accessed",
         "description",
     }
-    # assert cache.get_commit_codecell(pk, 0).source == "a=1\nprint(a)"
+    # assert cache.get_cache_codecell(pk, 0).source == "a=1\nprint(a)"
 
     path = os.path.join(NB_PATH, "basic_failing.ipynb")
-    diff = cache.diff_nbfile_with_commit(pk, path, as_str=True, use_color=False)
+    diff = cache.diff_nbfile_with_cache(pk, path, as_str=True, use_color=False)
     assert diff == dedent(
         f"""\
         nbdiff
-        --- committed pk=1
+        --- cached pk=1
         +++ other: {path}
         ## inserted before nb/cells/0:
         +  code cell:
@@ -66,10 +66,10 @@ def test_basic_workflow(tmp_path):
 
         """
     )
-    cache.remove_commit(pk)
-    assert cache.list_commit_records() == []
+    cache.remove_cache(pk)
+    assert cache.list_cache_records() == []
 
-    cache.commit_notebook_file(
+    cache.cache_notebook_file(
         path=os.path.join(NB_PATH, "basic.ipynb"),
         uri="basic.ipynb",
         check_validity=False,
@@ -91,12 +91,12 @@ def test_basic_workflow(tmp_path):
     assert bundle.nb.metadata
 
     cache.clear_cache()
-    assert cache.list_commit_records() == []
+    assert cache.list_cache_records() == []
 
 
 def test_merge_match_into_notebook(tmp_path):
     cache = JupyterCacheBase(str(tmp_path))
-    cache.commit_notebook_file(
+    cache.cache_notebook_file(
         path=os.path.join(NB_PATH, "basic.ipynb"), check_validity=False
     )
     nb = nbf.read(os.path.join(NB_PATH, "basic_unrun.ipynb"), 4)
@@ -113,19 +113,19 @@ def test_merge_match_into_notebook(tmp_path):
 def test_artifacts(tmp_path):
     cache = JupyterCacheBase(str(tmp_path))
     with pytest.raises(IOError):
-        cache.commit_notebook_file(
+        cache.cache_notebook_file(
             path=os.path.join(NB_PATH, "basic.ipynb"),
             uri="basic.ipynb",
             artifacts=(os.path.join(NB_PATH),),
             check_validity=False,
         )
-    cache.commit_notebook_file(
+    cache.cache_notebook_file(
         path=os.path.join(NB_PATH, "basic.ipynb"),
         uri="basic.ipynb",
         artifacts=(os.path.join(NB_PATH, "artifact_folder", "artifact.txt"),),
         check_validity=False,
     )
-    hashkey = cache.get_commit_record(1).hashkey
+    hashkey = cache.get_cache_record(1).hashkey
     assert {
         str(p.relative_to(tmp_path)) for p in tmp_path.glob("**/*") if p.is_file()
     } == {
@@ -134,7 +134,7 @@ def test_artifacts(tmp_path):
         f"executed/{hashkey}/artifacts/artifact_folder/artifact.txt",
     }
 
-    bundle = cache.get_commit_bundle(1)
+    bundle = cache.get_cache_bundle(1)
     assert {str(p) for p in bundle.artifacts.relative_paths} == {
         "artifact_folder/artifact.txt"
     }
@@ -142,7 +142,7 @@ def test_artifacts(tmp_path):
     text = list(h.read().decode() for r, h in bundle.artifacts)[0]
     assert text.rstrip() == "An artifact"
 
-    with cache.commit_artefacts_temppath(1) as path:
+    with cache.cache_artefacts_temppath(1) as path:
         assert path.joinpath("artifact_folder").exists()
 
 
@@ -161,8 +161,8 @@ def test_execution(tmp_path):
         os.path.join(NB_PATH, "basic_unrun.ipynb"),
         os.path.join(NB_PATH, "external_output.ipynb"),
     ]
-    assert len(db.list_commit_records()) == 2
-    bundle = db.get_commit_bundle(1)
+    assert len(db.list_cache_records()) == 2
+    bundle = db.get_cache_bundle(1)
     assert bundle.nb.cells[0] == {
         "cell_type": "code",
         "execution_count": 1,
@@ -170,8 +170,8 @@ def test_execution(tmp_path):
         "outputs": [{"name": "stdout", "output_type": "stream", "text": "1\n"}],
         "source": "a=1\nprint(a)",
     }
-    assert "execution_seconds" in bundle.commit.data
-    with db.commit_artefacts_temppath(2) as path:
+    assert "execution_seconds" in bundle.record.data
+    with db.cache_artefacts_temppath(2) as path:
         paths = [str(p.relative_to(path)) for p in path.glob("**/*") if p.is_file()]
         assert paths == ["artifact.txt"]
         assert path.joinpath("artifact.txt").read_text() == "hi"

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -146,6 +146,9 @@ def test_artifacts(tmp_path):
         assert path.joinpath("artifact_folder").exists()
 
 
+# jupyter_client/session.py:371: DeprecationWarning:
+# Session._key_changed is deprecated in traitlets: use @observe and @unobserve instead
+@pytest.mark.filterwarnings("ignore")
 def test_execution(tmp_path):
     from jupyter_cache.executors import load_executor
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,32 +25,32 @@ def test_clear_cache(tmp_path):
     assert "Cache cleared!" in result.output.strip(), result.output
 
 
-def test_list_commits(tmp_path):
+def test_list_caches(tmp_path):
     db = JupyterCacheBase(str(tmp_path))
-    db.commit_notebook_file(
+    db.cache_notebook_file(
         path=os.path.join(NB_PATH, "basic.ipynb"),
         uri="basic.ipynb",
         check_validity=False,
     )
     runner = CliRunner()
-    result = runner.invoke(cmd_cache.list_commits, ["-p", tmp_path])
+    result = runner.invoke(cmd_cache.list_caches, ["-p", tmp_path])
     assert result.exception is None, result.output
     assert result.exit_code == 0, result.output
     assert "basic.ipynb" in result.output.strip(), result.output
 
 
-def test_commit_with_artifact(tmp_path):
+def test_cache_with_artifact(tmp_path):
     JupyterCacheBase(str(tmp_path))
     nb_path = os.path.join(NB_PATH, "basic.ipynb")
     a_path = os.path.join(NB_PATH, "artifact_folder", "artifact.txt")
     runner = CliRunner()
     result = runner.invoke(
-        cmd_cache.commit_nb, ["-p", tmp_path, "--no-validate", "-nb", nb_path, a_path]
+        cmd_cache.cache_nb, ["-p", tmp_path, "--no-validate", "-nb", nb_path, a_path]
     )
     assert result.exception is None, result.output
     assert result.exit_code == 0, result.output
     assert "basic.ipynb" in result.output.strip(), result.output
-    result = runner.invoke(cmd_cache.show_commit, ["-p", tmp_path, "1"])
+    result = runner.invoke(cmd_cache.show_cache, ["-p", tmp_path, "1"])
     assert result.exception is None, result.output
     assert result.exit_code == 0, result.output
     assert "- artifact_folder/artifact.txt" in result.output.strip(), result.output
@@ -62,40 +62,38 @@ def test_commit_with_artifact(tmp_path):
     assert "An artifact" in result.output.strip(), result.output
 
 
-def test_commit_nbs(tmp_path):
+def test_cache_nbs(tmp_path):
     db = JupyterCacheBase(str(tmp_path))
     path = os.path.join(NB_PATH, "basic.ipynb")
     runner = CliRunner()
-    result = runner.invoke(
-        cmd_cache.commit_nbs, ["-p", tmp_path, "--no-validate", path]
-    )
+    result = runner.invoke(cmd_cache.cache_nbs, ["-p", tmp_path, "--no-validate", path])
     assert result.exception is None, result.output
     assert result.exit_code == 0, result.output
     assert "basic.ipynb" in result.output.strip(), result.output
-    assert db.list_commit_records()[0].uri == path
+    assert db.list_cache_records()[0].uri == path
 
 
-def test_remove_commits(tmp_path):
+def test_remove_caches(tmp_path):
     db = JupyterCacheBase(str(tmp_path))
-    db.commit_notebook_file(
+    db.cache_notebook_file(
         path=os.path.join(NB_PATH, "basic.ipynb"),
         uri="basic.ipynb",
         check_validity=False,
     )
     runner = CliRunner()
-    result = runner.invoke(cmd_cache.remove_commits, ["-p", tmp_path, "1"])
+    result = runner.invoke(cmd_cache.remove_caches, ["-p", tmp_path, "1"])
     assert result.exception is None, result.output
     assert result.exit_code == 0, result.output
     assert "Success" in result.output.strip(), result.output
-    assert db.list_commit_records() == []
+    assert db.list_cache_records() == []
 
 
 def test_diff_nbs(tmp_path):
     db = JupyterCacheBase(str(tmp_path))
     path = os.path.join(NB_PATH, "basic.ipynb")
     path2 = os.path.join(NB_PATH, "basic_failing.ipynb")
-    db.commit_notebook_file(path, check_validity=False)
-    # nb_bundle = db.get_commit_bundle(1)
+    db.cache_notebook_file(path, check_validity=False)
+    # nb_bundle = db.get_cache_bundle(1)
     # nb_bundle.nb.cells[0].source = "# New Title"
     # db.stage_notebook_bundle(nb_bundle)
 
@@ -105,7 +103,7 @@ def test_diff_nbs(tmp_path):
     assert result.exit_code == 0, result.output
     print(result.output.splitlines()[2:])
     assert result.output.splitlines()[1:] == [
-        "--- committed pk=1",
+        "--- cached pk=1",
         f"+++ other: {path2}",
         "## inserted before nb/cells/0:",
         "+  code cell:",
@@ -155,7 +153,7 @@ def test_unstage_nbs(tmp_path):
 
 def test_list_staged(tmp_path):
     db = JupyterCacheBase(str(tmp_path))
-    db.commit_notebook_file(
+    db.cache_notebook_file(
         path=os.path.join(NB_PATH, "basic.ipynb"), check_validity=False
     )
     db.stage_notebook_file(path=os.path.join(NB_PATH, "basic.ipynb"))
@@ -170,7 +168,7 @@ def test_list_staged(tmp_path):
 
 def test_show_staged(tmp_path):
     db = JupyterCacheBase(str(tmp_path))
-    db.commit_notebook_file(
+    db.cache_notebook_file(
         path=os.path.join(NB_PATH, "basic.ipynb"), check_validity=False
     )
     db.stage_notebook_file(path=os.path.join(NB_PATH, "basic.ipynb"))

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,6 +1,6 @@
 import pytest
 
-from jupyter_cache.cache.db import create_db, NbCommitRecord, Setting
+from jupyter_cache.cache.db import create_db, NbCacheRecord, Setting
 
 
 def test_setting(tmp_path):
@@ -12,10 +12,10 @@ def test_setting(tmp_path):
 
 def test_nb_record(tmp_path):
     db = create_db(tmp_path)
-    bundle = NbCommitRecord.create_record("a", "b", db)
+    bundle = NbCacheRecord.create_record("a", "b", db)
     assert bundle.hashkey == "b"
     with pytest.raises(ValueError):
-        NbCommitRecord.create_record("a", "b", db)
-    NbCommitRecord.create_record("a", "c", db, data="a")
-    assert NbCommitRecord.record_from_hashkey("b", db).uri == "a"
-    assert {b.hashkey for b in NbCommitRecord.records_from_uri("a", db)} == {"b", "c"}
+        NbCacheRecord.create_record("a", "b", db)
+    NbCacheRecord.create_record("a", "c", db, data="a")
+    assert NbCacheRecord.record_from_hashkey("b", db).uri == "a"
+    assert {b.hashkey for b in NbCacheRecord.records_from_uri("a", db)} == {"b", "c"}


### PR DESCRIPTION
Renamed everywhere in package.

Also renamed user-facing `PK` -> `ID`.

Addresses part of #16 feedback