### PR TITLE
Restructure CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ to come ...
 
 ## Example CLI usage
 
-From checked-out folder:
+From checked-out repository folder:
 
 ```console
 $ jcache -h
@@ -55,32 +55,41 @@ Options:
   -h, --help        Show this message and exit.
 
 Commands:
-  cache-limit    Change the maximum number of notebooks stored in the cache.
-  cache-nb       Cache a notebook that has already been executed.
-  cache-nbs      Cache notebook(s) that have already been executed.
-  cat-artifact   Print the contents of a cached artefact.
-  clear          Clear the cache completely.
-  diff-nb        Print a diff of a notebook to one stored in the cache.
-  execute        Execute outdated notebooks.
-  list-cached    List cached notebook records in the cache.
-  list-staged    List notebooks staged for possible execution.
-  remove-cached  Remove notebooks stored in the cache.
-  show-cached    Show details of a cached notebook in the cache.
-  show-staged    Show details of a staged notebook.
-  stage-nb       Cache a notebook, with possible assets.
-  stage-nbs      Stage notebook(s) for execution.
-  unstage-nbs    Unstage notebook(s) for execution.
+  cache    Commands for adding to and inspecting the cache.
+  clear    Clear the cache completely.
+  config   Commands for configuring the cache.
+  execute  Execute staged notebooks that are outdated.
+  stage    Commands for staging notebooks to be executed.
 ```
 
 ### Caching Executed Notebooks
 
-You can cache notebooks straight into the cache. When caching, a check will be made that the notebooks look to have been executed correctly, i.e. the cell execution counts go sequentially up from 1.
+```console
+$ jcache cache -h
+Usage: jcache cache [OPTIONS] COMMAND [ARGS]...
+
+  Commands for adding to and inspecting the cache.
+
+Options:
+  -h, --help  Show this message and exit.
+
+Commands:
+  add-many      Cache notebook(s) that have already been executed.
+  add-one       Cache a notebook that has already been executed.
+  cat-artifact  Print the contents of a cached artefact.
+  diff-nb       Print a diff of a notebook to one stored in the cache.
+  list          List cached notebook records in the cache.
+  remove        Remove notebooks stored in the cache.
+  show          Show details of a cached notebook in the cache.
+```
+
+You can add notebooks straight into the cache. When caching, a check will be made that the notebooks look to have been executed correctly, i.e. the cell execution counts go sequentially up from 1.
 
 ```console
-$ jcache cache-nbs tests/notebooks/basic.ipynb
-Cache path: /Users/cjs14/GitHub/sandbox/.jupyter_cache
+$ jcache cache add-many tests/notebooks/basic.ipynb
+Cache path: jupyter-cache/.jupyter_cache
 The cache does not yet exist, do you want to create it? [y/N]: y
-Caching: /Users/cjs14/GitHub/sandbox/tests/notebooks/basic.ipynb
+Caching: jupyter-cache/tests/notebooks/basic.ipynb
 Validity Error: Expected cell 1 to have execution_count 1 not 2
 The notebook may not have been executed, continue caching? [y/N]: y
 Success!
@@ -89,11 +98,12 @@ Success!
 Or to skip validation:
 
 ```console
-$ jcache cache-nbs --no-validate tests/notebooks/*.ipynb
-Caching: /Users/cjs14/GitHub/sandbox/tests/notebooks/basic.ipynb
-Caching: /Users/cjs14/GitHub/sandbox/tests/notebooks/basic_failing.ipynb
-Caching: /Users/cjs14/GitHub/sandbox/tests/notebooks/basic_unrun.ipynb
-Caching: /Users/cjs14/GitHub/sandbox/tests/notebooks/complex_outputs.ipynb
+jcache cache add-many --no-validate tests/notebooks/*.ipynb
+Caching: jupyter-cache/tests/notebooks/basic.ipynb
+Caching: jupyter-cache/tests/notebooks/basic_failing.ipynb
+Caching: jupyter-cache/tests/notebooks/basic_unrun.ipynb
+Caching: jupyter-cache/tests/notebooks/complex_outputs.ipynb
+Caching: jupyter-cache/tests/notebooks/external_output.ipynb
 Success!
 ```
 
@@ -102,60 +112,67 @@ Once you've cached some notebooks, you can look at the 'cache records' for what 
 Each notebook is hashed (code cells and kernel spec only), which is used to compare against 'staged' notebooks. Multiple hashes for the same URI can be added (the URI is just there for inspetion) and the size of the cache is limited (current default 1000) so that, at this size, the last accessed records begin to be deleted. You can remove cached records by their ID.
 
 ```console
-$ jcache list-cached --hashkeys
-  ID  URI                    Created           Accessed          Hashkey
-----  ---------------------  ----------------  ----------------  --------------------------------
-   4  complex_outputs.ipynb  2020-02-23 20:33  2020-02-23 20:33  800c4a057730a55a384cfe579e3850aa
-   3  basic_unrun.ipynb      2020-02-23 20:33  2020-02-23 20:33  818f3412b998fcf4fe9ca3cca11a3fc3
-   2  basic_failing.ipynb    2020-02-23 20:33  2020-02-23 20:33  72859c2bf1e12f35f30ef131f0bef320
+$ jcache cache list
+  ID  URI                                    Created           Accessed
+----  -------------------------------------  ----------------  ----------------
+   5  tests/notebooks/external_output.ipynb  2020-02-29 03:17  2020-02-29 03:17
+   4  tests/notebooks/complex_outputs.ipynb  2020-02-29 03:17  2020-02-29 03:17
+   3  tests/notebooks/basic_unrun.ipynb      2020-02-29 03:17  2020-02-29 03:17
+   2  tests/notebooks/basic_failing.ipynb    2020-02-29 03:17  2020-02-29 03:17
 ```
 
 You can also cache notebooks with artefacts (external outputs of the notebook execution).
 
 ```console
-$ jcache cache-nb -nb tests/notebooks/basic.ipynb tests/notebooks/artifact_folder/artifact.txt
-Caching: /Users/cjs14/GitHub/jupyter-cache/tests/notebooks/basic.ipynb
+$ jcache cache add-one -nb tests/notebooks/basic.ipynb tests/notebooks/artifact_folder/artifact.txt
+Caching: jupyter-cache/tests/notebooks/basic.ipynb
 Success!
 ```
 
+Show a full description of a cached notebook by referring to its ID
+
 ```console
-$ jcache show-cached 1
-ID: 1
-URI: /Users/cjs14/GitHub/jupyter-cache/tests/notebooks/basic.ipynb
-Created: 2020-02-24 14:58
-Accessed: 2020-02-24 14:58
+$ jcache cache show 6
+ID: 6
+URI: jupyter-cache/tests/notebooks/basic.ipynb
+Created: 2020-02-29 03:19
+Accessed: 2020-02-29 03:19
 Hashkey: 818f3412b998fcf4fe9ca3cca11a3fc3
 Artifacts:
 - artifact_folder/artifact.txt
 ```
 
+Note artefact paths must be 'upstream' of the notebook folder:
+
 ```console
-$ jcache cat-artifact 1 artifact_folder/artifact.txt
+$ jcache cache add-one -nb tests/notebooks/basic.ipynb tests/test_db.py
+Caching: jupyter-cache/tests/notebooks/basic.ipynb
+Artifact Error: Path 'jupyter-cache/tests/test_db.py' is not in folder 'jupyter-cache/tests/notebooks''
+```
+
+To view the contents of an execution artefact:
+
+```console
+$ jcache cache cat-artifact 1 artifact_folder/artifact.txt
 An artifact
 
 ```
 
-These must be 'upstream' of the notebook folder:
+You can directly remove a cached notebook by its ID:
 
 ```console
-$ jcache cache-nb -nb tests/notebooks/basic.ipynb tests/test_db.py
-Caching: /Users/cjs14/GitHub/jupyter-cache/tests/notebooks/basic.ipynb
-Artifact Error: Path '/Users/cjs14/GitHub/jupyter-cache/tests/test_db.py' is not in folder '/Users/cjs14/GitHub/jupyter-cache/tests/notebooks''
-```
-
-```console
-$ jcache remove-cached 3
-Removing Cache ID = 3
+$ jcache cache remove 4
+Removing Cache ID = 4
 Success!
 ```
 
 You can also diff any of the cached notebooks with any (external) notebook:
 
 ```console
-$ jcache diff-nb 2 tests/notebooks/basic.ipynb
+$ jcache cache diff-nb 2 tests/notebooks/basic.ipynb
 nbdiff
 --- cached pk=2
-+++ other: /Users/cjs14/GitHub/sandbox/tests/notebooks/basic.ipynb
++++ other: sandbox/tests/notebooks/basic.ipynb
 ## inserted before nb/cells/1:
 +  code cell:
 +    execution_count: 2
@@ -177,38 +194,71 @@ nbdiff
 
 ### Staging Notebooks for execution
 
+```console
+$ jcache stage -h
+Usage: jcache stage [OPTIONS] COMMAND [ARGS]...
+
+  Commands for staging notebooks to be executed.
+
+Options:
+  -h, --help  Show this message and exit.
+
+Commands:
+  add-many     Stage notebook(s) for execution.
+  add-one      Stage a notebook, with possible assets.
+  list         List notebooks staged for possible execution.
+  remove-ids   Un-stage notebook(s), by ID.
+  remove-uris  Un-stage notebook(s), by URI.
+  show         Show details of a staged notebook.
+```
+
 Staged notebooks are recorded as pointers to their URI,
 i.e. no physical copying takes place until execution time.
 
-If you stage some notebooks for execution, then you can list them to see which have existing records in the cache (by hash) and which will require execution:
+If you stage some notebooks for execution,
+then you can list them to see which have existing records in the cache (by hash),
+and which will require execution:
 
 ```console
-$ jcache stage-nbs tests/notebooks/*.ipynb
-Staging: /Users/cjs14/GitHub/sandbox/tests/notebooks/basic.ipynb
-Staging: /Users/cjs14/GitHub/sandbox/tests/notebooks/basic_failing.ipynb
-Staging: /Users/cjs14/GitHub/sandbox/tests/notebooks/basic_unrun.ipynb
-Staging: /Users/cjs14/GitHub/sandbox/tests/notebooks/complex_outputs.ipynb
+$ jcache stage add-many tests/notebooks/*.ipynb
+Staging: jupyter-cache/tests/notebooks/basic.ipynb
+Staging: jupyter-cache/tests/notebooks/basic_failing.ipynb
+Staging: jupyter-cache/tests/notebooks/basic_unrun.ipynb
+Staging: jupyter-cache/tests/notebooks/complex_outputs.ipynb
+Staging: jupyter-cache/tests/notebooks/external_output.ipynb
 Success!
 ```
 
 ```console
-$ jcache list-staged
-  ID  URI                                    Created              Cache ID
-----  -------------------------------------  ----------------  -----------
-   4  tests/notebooks/complex_outputs.ipynb  2020-02-23 20:48            4
-   3  tests/notebooks/basic_unrun.ipynb      2020-02-23 20:48
-   2  tests/notebooks/basic_failing.ipynb    2020-02-23 20:48            2
-   1  tests/notebooks/basic.ipynb            2020-02-23 20:48
+$ jcache stage list
+  ID  URI                                    Created             Assets    Cache ID
+----  -------------------------------------  ----------------  --------  ----------
+   5  tests/notebooks/external_output.ipynb  2020-02-29 03:29         0           5
+   4  tests/notebooks/complex_outputs.ipynb  2020-02-29 03:29         0
+   3  tests/notebooks/basic_unrun.ipynb      2020-02-29 03:29         0           6
+   2  tests/notebooks/basic_failing.ipynb    2020-02-29 03:29         0           2
+   1  tests/notebooks/basic.ipynb            2020-02-29 03:29         0           6
+```
+
+You can remove a staged notebook by its URI or ID:
+
+```console
+$ jcache stage remove-ids 4
+Unstaging ID: 4
+Success!
 ```
 
 You can then run a basic execution of the required notebooks:
 
 ```console
+$ jcache cache remove 6
+Removing Cache ID = 6
+Success!
 $ jcache execute
-Executing: /Users/cjs14/GitHub/sandbox/tests/notebooks/basic.ipynb
-Success: /Users/cjs14/GitHub/sandbox/tests/notebooks/basic.ipynb
-Executing: /Users/cjs14/GitHub/sandbox/tests/notebooks/basic_unrun.ipynb
-Success: /Users/cjs14/GitHub/sandbox/tests/notebooks/basic_unrun.ipynb
+Executing: jupyter-cache/tests/notebooks/basic.ipynb
+Success: jupyter-cache/tests/notebooks/basic.ipynb
+Executing: jupyter-cache/tests/notebooks/basic_unrun.ipynb
+Success: jupyter-cache/tests/notebooks/basic_unrun.ipynb
 Finished!
 ```
 
@@ -216,32 +266,35 @@ Successfully executed notebooks will be cached to the cache,
 along with any 'artefacts' created by the execution, that are inside the notebook folder, and data supplied by the executor.
 
 ```console
-$ jcache list-staged
-  ID  URI                                    Created             Commit ID
-----  -------------------------------------  ----------------  -----------
-   5  tests/notebooks/basic.ipynb            2020-02-23 20:57            5
-   4  tests/notebooks/complex_outputs.ipynb  2020-02-23 20:48            4
-   3  tests/notebooks/basic_unrun.ipynb      2020-02-23 20:48            6
-   2  tests/notebooks/basic_failing.ipynb    2020-02-23 20:48            2
+$ jcache stage list
+  ID  URI                                    Created             Assets    Cache ID
+----  -------------------------------------  ----------------  --------  ----------
+   5  tests/notebooks/external_output.ipynb  2020-02-29 03:29         0           5
+   3  tests/notebooks/basic_unrun.ipynb      2020-02-29 03:29         0           6
+   2  tests/notebooks/basic_failing.ipynb    2020-02-29 03:29         0           2
+   1  tests/notebooks/basic.ipynb            2020-02-29 03:29         0           6
 ```
 
 ```console
-jcache show-cached 5
-ID: 1
-URI: /Users/cjs14/GitHub/jupyter-cache/tests/notebooks/basic.ipynb
-Created: 2020-02-25 19:21
-Accessed: 2020-02-25 19:21
+$ jcache cache show 6
+ID: 6
+URI: jupyter-cache/tests/notebooks/basic_unrun.ipynb
+Created: 2020-02-29 03:41
+Accessed: 2020-02-29 03:41
 Hashkey: 818f3412b998fcf4fe9ca3cca11a3fc3
 Data:
-  execution_seconds: 1.4187269599999999
+  execution_seconds: 1.2328746560000003
 ```
 
 Once executed you may leave staged notebooks, for later re-execution, or remove them:
 
 ```console
-$ jcache unstage-nbs --all
+$ jcache stage remove-ids --all
 Are you sure you want to remove all? [y/N]: y
-Unstaging: /Users/cjs14/GitHub/jupyter-cache/tests/notebooks/basic.ipynb
+Unstaging ID: 1
+Unstaging ID: 2
+Unstaging ID: 3
+Unstaging ID: 5
 Success!
 ```
 
@@ -249,24 +302,24 @@ You can also stage notebooks with assets; external files that are required by th
 these files must be in the same folder as the notebook, or a sub-folder.
 
 ```console
-$ jcache stage-nb -nb tests/notebooks/basic.ipynb tests/notebooks/artifact_folder/artifact.txt
+$ jcache stage add-one -nb tests/notebooks/basic.ipynb tests/notebooks/artifact_folder/artifact.txt
 Success!
 ```
 
 ```console
-$ jcache list-staged
+$ jcache stage list
   ID  URI                          Created             Assets
 ----  ---------------------------  ----------------  --------
    1  tests/notebooks/basic.ipynb  2020-02-25 10:01         1
 ```
 
 ```console
-$ jcache show-staged 1
+$ jcache stage show 1
 ID: 1
-URI: /Users/cjs14/GitHub/jupyter-cache/tests/notebooks/basic.ipynb
+URI: jupyter-cache/tests/notebooks/basic.ipynb
 Created: 2020-02-25 10:01
 Assets:
-- /Users/cjs14/GitHub/jupyter-cache/tests/notebooks/artifact_folder/artifact.txt
+- jupyter-cache/tests/notebooks/artifact_folder/artifact.txt
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -50,9 +50,10 @@ Usage: jcache [OPTIONS] COMMAND [ARGS]...
   The command line interface of jupyter-cache.
 
 Options:
-  -v, --version     Show the version and exit.
-  -p, --cache-path  Print the current cache path and exit.
-  -h, --help        Show this message and exit.
+  -v, --version       Show the version and exit.
+  -p, --cache-path    Print the current cache path and exit.
+  -a, --autocomplete  Print the terminal autocompletion command and exit.
+  -h, --help          Show this message and exit.
 
 Commands:
   cache    Commands for adding to and inspecting the cache.
@@ -60,6 +61,12 @@ Commands:
   config   Commands for configuring the cache.
   execute  Execute staged notebooks that are outdated.
   stage    Commands for staging notebooks to be executed.
+```
+
+**Important**: Execute this in the terminal for auto-completion:
+
+```console
+eval "$(_JCACHE_COMPLETE=source jcache)"
 ```
 
 ### Caching Executed Notebooks

--- a/README.md
+++ b/README.md
@@ -55,72 +55,72 @@ Options:
   -h, --help        Show this message and exit.
 
 Commands:
-  cat-artifact    Print the contents of a commit artefact.
-  clear           Clear the cache completely.
-  commit-limit    Change the commit limit of the cache.
-  commit-nb       Commit a notebook that has already been executed.
-  commit-nbs      Commit notebook(s) that have already been executed.
-  diff-nb         Print a diff of a notebook to one stored in the cache.
-  execute         Execute outdated notebooks.
-  list-commits    List committed notebook records in the cache.
-  list-staged     List notebooks staged for possible execution.
-  remove-commits  Remove notebook commit(s) from the cache.
-  show-commit     Show details of a committed notebook in the cache.
-  show-staged     Show details of a staged notebook.
-  stage-nb        Commit a notebook, with possible assets.
-  stage-nbs       Stage notebook(s) for execution.
-  unstage-nbs     Unstage notebook(s) for execution.
+  cache-limit    Change the maximum number of notebooks stored in the cache.
+  cache-nb       Cache a notebook that has already been executed.
+  cache-nbs      Cache notebook(s) that have already been executed.
+  cat-artifact   Print the contents of a cached artefact.
+  clear          Clear the cache completely.
+  diff-nb        Print a diff of a notebook to one stored in the cache.
+  execute        Execute outdated notebooks.
+  list-cached    List cached notebook records in the cache.
+  list-staged    List notebooks staged for possible execution.
+  remove-cached  Remove notebooks stored in the cache.
+  show-cached    Show details of a cached notebook in the cache.
+  show-staged    Show details of a staged notebook.
+  stage-nb       Cache a notebook, with possible assets.
+  stage-nbs      Stage notebook(s) for execution.
+  unstage-nbs    Unstage notebook(s) for execution.
 ```
 
-### Commit Executed Notebooks
+### Caching Executed Notebooks
 
-You can commit notebooks straight into the cache. When committing, a check will be made that the notebooks look to have been executed correctly, i.e. the cell execution counts go sequentially up from 1.
+You can cache notebooks straight into the cache. When caching, a check will be made that the notebooks look to have been executed correctly, i.e. the cell execution counts go sequentially up from 1.
 
 ```console
-$ jcache commit-nbs tests/notebooks/basic.ipynb
+$ jcache cache-nbs tests/notebooks/basic.ipynb
 Cache path: /Users/cjs14/GitHub/sandbox/.jupyter_cache
 The cache does not yet exist, do you want to create it? [y/N]: y
-Committing: /Users/cjs14/GitHub/sandbox/tests/notebooks/basic.ipynb
+Caching: /Users/cjs14/GitHub/sandbox/tests/notebooks/basic.ipynb
 Validity Error: Expected cell 1 to have execution_count 1 not 2
-The notebook may not have been executed, continue committing? [y/N]: y
+The notebook may not have been executed, continue caching? [y/N]: y
 Success!
 ```
 
 Or to skip validation:
 
 ```console
-$ jcache commit-nbs --no-validate tests/notebooks/*.ipynb
-Committing: /Users/cjs14/GitHub/sandbox/tests/notebooks/basic.ipynb
-Committing: /Users/cjs14/GitHub/sandbox/tests/notebooks/basic_failing.ipynb
-Committing: /Users/cjs14/GitHub/sandbox/tests/notebooks/basic_unrun.ipynb
-Committing: /Users/cjs14/GitHub/sandbox/tests/notebooks/complex_outputs.ipynb
+$ jcache cache-nbs --no-validate tests/notebooks/*.ipynb
+Caching: /Users/cjs14/GitHub/sandbox/tests/notebooks/basic.ipynb
+Caching: /Users/cjs14/GitHub/sandbox/tests/notebooks/basic_failing.ipynb
+Caching: /Users/cjs14/GitHub/sandbox/tests/notebooks/basic_unrun.ipynb
+Caching: /Users/cjs14/GitHub/sandbox/tests/notebooks/complex_outputs.ipynb
 Success!
 ```
 
-Once you've committed some notebooks, you can look at the 'commit records' for what has been cached.
+Once you've cached some notebooks, you can look at the 'cache records' for what has been cached.
 
-Each notebook is hashed (code cells and kernel spec only), which is used to compare against 'staged' notebooks. Multiple hashes for the same URI can be added (the URI is just there for inspetion) and the size of the cache is limited (current default 1000) so that, at this size, the last accessed records begin to be deleted. You can remove cached records by the Primary Key (PK).
+Each notebook is hashed (code cells and kernel spec only), which is used to compare against 'staged' notebooks. Multiple hashes for the same URI can be added (the URI is just there for inspetion) and the size of the cache is limited (current default 1000) so that, at this size, the last accessed records begin to be deleted. You can remove cached records by their ID.
 
 ```console
-$ jcache list-commits --hashkeys
-  PK  URI                    Created           Accessed          Hashkey
+$ jcache list-cached --hashkeys
+  ID  URI                    Created           Accessed          Hashkey
 ----  ---------------------  ----------------  ----------------  --------------------------------
    4  complex_outputs.ipynb  2020-02-23 20:33  2020-02-23 20:33  800c4a057730a55a384cfe579e3850aa
    3  basic_unrun.ipynb      2020-02-23 20:33  2020-02-23 20:33  818f3412b998fcf4fe9ca3cca11a3fc3
    2  basic_failing.ipynb    2020-02-23 20:33  2020-02-23 20:33  72859c2bf1e12f35f30ef131f0bef320
 ```
 
-You can also commit with artefacts (external outputs of the notebook execution).
+You can also cache notebooks with artefacts (external outputs of the notebook execution).
 
 ```console
-$ jcache commit-nb -nb tests/notebooks/basic.ipynb tests/notebooks/artifact_folder/artifact.txt
-Committing: /Users/cjs14/GitHub/jupyter-cache/tests/notebooks/basic.ipynb
+$ jcache cache-nb -nb tests/notebooks/basic.ipynb tests/notebooks/artifact_folder/artifact.txt
+Caching: /Users/cjs14/GitHub/jupyter-cache/tests/notebooks/basic.ipynb
 Success!
 ```
 
 ```console
-$ jcache show-commit 1
-PK: 1
+$ jcache show-cached 1
+ID: 1
 URI: /Users/cjs14/GitHub/jupyter-cache/tests/notebooks/basic.ipynb
 Created: 2020-02-24 14:58
 Accessed: 2020-02-24 14:58
@@ -138,23 +138,23 @@ An artifact
 These must be 'upstream' of the notebook folder:
 
 ```console
-$ jcache commit-nb -nb tests/notebooks/basic.ipynb tests/test_db.py
-Committing: /Users/cjs14/GitHub/jupyter-cache/tests/notebooks/basic.ipynb
+$ jcache cache-nb -nb tests/notebooks/basic.ipynb tests/test_db.py
+Caching: /Users/cjs14/GitHub/jupyter-cache/tests/notebooks/basic.ipynb
 Artifact Error: Path '/Users/cjs14/GitHub/jupyter-cache/tests/test_db.py' is not in folder '/Users/cjs14/GitHub/jupyter-cache/tests/notebooks''
 ```
 
 ```console
-$ jcache remove-commits 3
-Removing PK = 3
+$ jcache remove-cached 3
+Removing Cache ID = 3
 Success!
 ```
 
-You can also diff any of the commit records with any (external) notebook:
+You can also diff any of the cached notebooks with any (external) notebook:
 
 ```console
 $ jcache diff-nb 2 tests/notebooks/basic.ipynb
 nbdiff
---- committed pk=2
+--- cached pk=2
 +++ other: /Users/cjs14/GitHub/sandbox/tests/notebooks/basic.ipynb
 ## inserted before nb/cells/1:
 +  code cell:
@@ -193,7 +193,7 @@ Success!
 
 ```console
 $ jcache list-staged
-  PK  URI                                    Created             Commit Pk
+  ID  URI                                    Created              Cache ID
 ----  -------------------------------------  ----------------  -----------
    4  tests/notebooks/complex_outputs.ipynb  2020-02-23 20:48            4
    3  tests/notebooks/basic_unrun.ipynb      2020-02-23 20:48
@@ -212,12 +212,12 @@ Success: /Users/cjs14/GitHub/sandbox/tests/notebooks/basic_unrun.ipynb
 Finished!
 ```
 
-Successfully executed notebooks will be committed to the cache,
+Successfully executed notebooks will be cached to the cache,
 along with any 'artefacts' created by the execution, that are inside the notebook folder, and data supplied by the executor.
 
 ```console
 $ jcache list-staged
-  PK  URI                                    Created             Commit Pk
+  ID  URI                                    Created             Commit ID
 ----  -------------------------------------  ----------------  -----------
    5  tests/notebooks/basic.ipynb            2020-02-23 20:57            5
    4  tests/notebooks/complex_outputs.ipynb  2020-02-23 20:48            4
@@ -226,8 +226,8 @@ $ jcache list-staged
 ```
 
 ```console
-jcache show-commit 5
-PK: 1
+jcache show-cached 5
+ID: 1
 URI: /Users/cjs14/GitHub/jupyter-cache/tests/notebooks/basic.ipynb
 Created: 2020-02-25 19:21
 Accessed: 2020-02-25 19:21
@@ -255,14 +255,14 @@ Success!
 
 ```console
 $ jcache list-staged
-  PK  URI                          Created             Assets
+  ID  URI                          Created             Assets
 ----  ---------------------------  ----------------  --------
    1  tests/notebooks/basic.ipynb  2020-02-25 10:01         1
 ```
 
 ```console
 $ jcache show-staged 1
-PK: 1
+ID: 1
 URI: /Users/cjs14/GitHub/jupyter-cache/tests/notebooks/basic.ipynb
 Created: 2020-02-25 10:01
 Assets:

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Options:
 
 Commands:
   add-many      Cache notebook(s) that have already been executed.
-  add-one       Cache a notebook that has already been executed.
+  add-one       Cache a notebook, with possible artefact files.
   cat-artifact  Print the contents of a cached artefact.
   diff-nb       Print a diff of a notebook to one stored in the cache.
   list          List cached notebook records in the cache.
@@ -212,7 +212,7 @@ Options:
 
 Commands:
   add-many     Stage notebook(s) for execution.
-  add-one      Stage a notebook, with possible assets.
+  add-one      Stage a notebook, with possible asset files.
   list         List notebooks staged for possible execution.
   remove-ids   Un-stage notebook(s), by ID.
   remove-uris  Un-stage notebook(s), by URI.

--- a/jupyter_cache/cache/__init__.py
+++ b/jupyter_cache/cache/__init__.py
@@ -1,1 +1,0 @@
-from .main import JupyterCacheBase, DEFAULT_CACHE_LIMIT  # noqa: F401

--- a/jupyter_cache/cache/__init__.py
+++ b/jupyter_cache/cache/__init__.py
@@ -1,1 +1,1 @@
-from .main import JupyterCacheBase, DEFAULT_COMMIT_LIMIT  # noqa: F401
+from .main import JupyterCacheBase, DEFAULT_CACHE_LIMIT  # noqa: F401

--- a/jupyter_cache/cli/arguments.py
+++ b/jupyter_cache/cli/arguments.py
@@ -31,6 +31,6 @@ ASSET_PATHS = click.argument(
 )
 
 
-PK = click.argument("pk", metavar="PK", type=int)
+PK = click.argument("pk", metavar="ID", type=int)
 
-PKS = click.argument("pks", metavar="PKs", nargs=-1, type=int)
+PKS = click.argument("pks", metavar="IDs", nargs=-1, type=int)

--- a/jupyter_cache/cli/commands/__init__.py
+++ b/jupyter_cache/cli/commands/__init__.py
@@ -1,3 +1,8 @@
+import click_completion
+
+# Activate the completion of parameter types provided by the click_completion package
+click_completion.init()
+
 from .cmd_cache import *  # noqa: F401,F403
 from .cmd_config import *  # noqa: F401,F403
 from .cmd_exec import *  # noqa: F401,F403

--- a/jupyter_cache/cli/commands/__init__.py
+++ b/jupyter_cache/cli/commands/__init__.py
@@ -1,2 +1,4 @@
 from .cmd_cache import *  # noqa: F401,F403
+from .cmd_config import *  # noqa: F401,F403
 from .cmd_exec import *  # noqa: F401,F403
+from .cmd_stage import *  # noqa: F401,F403

--- a/jupyter_cache/cli/commands/cmd_cache.py
+++ b/jupyter_cache/cli/commands/cmd_cache.py
@@ -138,7 +138,7 @@ def cache_file(db, nbpath, validate, overwrite, artifact_paths=()):
 @options.VALIDATE_NB
 @options.OVERWRITE_CACHED
 def cache_nb(cache_path, artifact_paths, nbpath, validate, overwrite):
-    """Cache a notebook that has already been executed."""
+    """Cache a notebook, with possible artefact files."""
     db = get_cache(cache_path)
     success = cache_file(db, nbpath, validate, overwrite, artifact_paths)
     if success:

--- a/jupyter_cache/cli/commands/cmd_cache.py
+++ b/jupyter_cache/cli/commands/cmd_cache.py
@@ -62,7 +62,11 @@ def list_caches(cache_path, hashkeys, path_length):
 def show_cache(cache_path, pk):
     """Show details of a cached notebook in the cache."""
     db = JupyterCacheBase(cache_path)
-    record = db.get_cache_record(pk)
+    try:
+        record = db.get_cache_record(pk)
+    except KeyError:
+        click.secho("ID {} does not exist, Aborting!".format(pk), fg="red")
+        sys.exit(1)
     data = format_cache_record(record, True, None)
     click.echo(yaml.safe_dump(data, sort_keys=False), nl=False)
     with db.cache_artefacts_temppath(pk) as folder:

--- a/jupyter_cache/cli/commands/cmd_cache.py
+++ b/jupyter_cache/cli/commands/cmd_cache.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 import sys
 
 import click
@@ -7,6 +6,7 @@ import yaml
 
 from jupyter_cache.cli.commands.cmd_main import jcache
 from jupyter_cache.cli import arguments, options
+from jupyter_cache.cli.utils import shorten_path
 from jupyter_cache.cache import JupyterCacheBase
 from jupyter_cache.base import (  # noqa: F401
     CachingError,
@@ -15,33 +15,10 @@ from jupyter_cache.base import (  # noqa: F401
 )
 
 
-def shorten_path(file_path, length):
-    """Split the path into separate parts,
-    select the last 'length' elements and join them again
-    """
-    if length is None:
-        return Path(file_path)
-    return Path(*Path(file_path).parts[-length:])
-
-
-@jcache.command("clear")
-@options.CACHE_PATH
-def clear_cache(cache_path):
-    """Clear the cache completely."""
-    db = JupyterCacheBase(cache_path)
-    click.confirm("Are you sure you want to permanently clear the cache!?", abort=True)
-    db.clear_cache()
-    click.secho("Cache cleared!", fg="green")
-
-
-@jcache.command("cache-limit")
-@options.CACHE_PATH
-@click.argument("limit", metavar="CACHE_LIMIT", type=int)
-def change_cache_limit(cache_path, limit):
-    """Change the maximum number of notebooks stored in the cache."""
-    db = JupyterCacheBase(cache_path)
-    db.change_cache_limit(limit)
-    click.secho("Cache limit changed!", fg="green")
+@jcache.group("cache")
+def cmnd_cache():
+    """Commands for adding to and inspecting the cache."""
+    pass
 
 
 def format_cache_record(record, hashkeys, path_length):
@@ -57,7 +34,7 @@ def format_cache_record(record, hashkeys, path_length):
     return data
 
 
-@jcache.command("list-cached")
+@cmnd_cache.command("list")
 @options.CACHE_PATH
 @click.option("-h", "--hashkeys", is_flag=True, help="Whether to show hashkeys.")
 @options.PATH_LENGTH
@@ -79,7 +56,7 @@ def list_caches(cache_path, hashkeys, path_length):
     )
 
 
-@jcache.command("show-cached")
+@cmnd_cache.command("show")
 @options.CACHE_PATH
 @arguments.PK
 def show_cache(cache_path, pk):
@@ -101,7 +78,7 @@ def show_cache(cache_path, pk):
         click.echo(yaml.safe_dump({"Data": record.data}))
 
 
-@jcache.command("cat-artifact")
+@cmnd_cache.command("cat-artifact")
 @options.CACHE_PATH
 @arguments.PK
 @arguments.ARTIFACT_RPATH
@@ -151,7 +128,7 @@ def cache_file(db, nbpath, validate, overwrite, artifact_paths=()):
     return True
 
 
-@jcache.command("cache-nb")
+@cmnd_cache.command("add-one")
 @arguments.ARTIFACT_PATHS
 @options.NB_PATH
 @options.CACHE_PATH
@@ -165,7 +142,7 @@ def cache_nb(cache_path, artifact_paths, nbpath, validate, overwrite):
         click.secho("Success!", fg="green")
 
 
-@jcache.command("cache-nbs")
+@cmnd_cache.command("add-many")
 @arguments.NB_PATHS
 @options.CACHE_PATH
 @options.VALIDATE_NB
@@ -182,7 +159,7 @@ def cache_nbs(cache_path, nbpaths, validate, overwrite):
         click.secho("Success!", fg="green")
 
 
-@jcache.command("remove-cached")
+@cmnd_cache.command("remove")
 @arguments.PKS
 @options.CACHE_PATH
 @options.REMOVE_ALL
@@ -204,7 +181,7 @@ def remove_caches(cache_path, pks, remove_all):
     click.secho("Success!", fg="green")
 
 
-@jcache.command("diff-nb")
+@cmnd_cache.command("diff-nb")
 @arguments.PK
 @arguments.NB_PATH
 @options.CACHE_PATH
@@ -213,98 +190,3 @@ def diff_nb(cache_path, pk, nbpath):
     db = JupyterCacheBase(cache_path)
     click.echo(db.diff_nbfile_with_cache(pk, nbpath, as_str=True))
     click.secho("Success!", fg="green")
-
-
-@jcache.command("stage-nbs")
-@arguments.NB_PATHS
-@options.CACHE_PATH
-def stage_nbs(cache_path, nbpaths):
-    """Stage notebook(s) for execution."""
-    db = JupyterCacheBase(cache_path)
-    for path in nbpaths:
-        # TODO deal with errors (print all at end? or option to ignore)
-        click.echo("Staging: {}".format(path))
-        db.stage_notebook_file(path)
-    click.secho("Success!", fg="green")
-
-
-@jcache.command("stage-nb")
-@arguments.ASSET_PATHS
-@options.NB_PATH
-@options.CACHE_PATH
-def stage_nb(cache_path, nbpath, asset_paths):
-    """Cache a notebook, with possible assets."""
-    db = JupyterCacheBase(cache_path)
-    db.stage_notebook_file(nbpath, asset_paths)
-    click.secho("Success!", fg="green")
-
-
-@jcache.command("unstage-nbs")
-@arguments.NB_PATHS
-@options.CACHE_PATH
-@options.REMOVE_ALL
-def unstage_nbs(cache_path, nbpaths, remove_all):
-    """Unstage notebook(s) for execution."""
-    db = JupyterCacheBase(cache_path)
-    if remove_all:
-        nbpaths = [record.uri for record in db.list_staged_records()]
-    for path in nbpaths:
-        # TODO deal with errors (print all at end? or option to ignore)
-        click.echo("Unstaging: {}".format(path))
-        db.discard_staged_notebook(path)
-    click.secho("Success!", fg="green")
-
-
-def format_staged_record(record, cache_record, path_length, assets=True):
-    data = {
-        "ID": record.pk,
-        "URI": str(shorten_path(record.uri, path_length)),
-        "Created": record.created.isoformat(" ", "minutes"),
-    }
-    if assets:
-        data["Assets"] = len(record.assets)
-    if cache_record:
-        data["Cache ID"] = cache_record.pk
-    return data
-
-
-@jcache.command("list-staged")
-@options.CACHE_PATH
-@click.option(
-    "--compare/--no-compare",
-    default=True,
-    show_default=True,
-    help="Compare to cached notebooks (to find cache ID).",
-)
-@options.PATH_LENGTH
-def list_staged(cache_path, compare, path_length):
-    """List notebooks staged for possible execution."""
-    db = JupyterCacheBase(cache_path)
-    records = db.list_staged_records()
-    if not records:
-        click.secho("No Staged Notebooks", fg="blue")
-    rows = []
-    for record in sorted(records, key=lambda r: r.created, reverse=True):
-        cache_record = None
-        if compare:
-            cache_record = db.get_cache_record_of_staged(record.uri)
-        rows.append(format_staged_record(record, cache_record, path_length))
-    click.echo(tabulate.tabulate(rows, headers="keys"))
-
-
-@jcache.command("show-staged")
-@options.CACHE_PATH
-@arguments.PK
-def show_staged(cache_path, pk):
-    """Show details of a staged notebook."""
-    db = JupyterCacheBase(cache_path)
-    record = db.get_staged_record(pk)
-    cache_record = db.get_cache_record_of_staged(record.uri)
-    data = format_staged_record(record, cache_record, None, assets=False)
-    click.echo(yaml.safe_dump(data, sort_keys=False), nl=False)
-    if not record.assets:
-        click.echo("")
-        return
-    click.echo(f"Assets:")
-    for path in record.assets:
-        click.echo(f"- {path}")

--- a/jupyter_cache/cli/commands/cmd_config.py
+++ b/jupyter_cache/cli/commands/cmd_config.py
@@ -1,0 +1,21 @@
+import click
+
+from jupyter_cache.cache import JupyterCacheBase
+from jupyter_cache.cli.commands.cmd_main import jcache
+from jupyter_cache.cli import options
+
+
+@jcache.group("config")
+def cmnd_config():
+    """Commands for configuring the cache."""
+    pass
+
+
+@cmnd_config.command("cache-limit")
+@options.CACHE_PATH
+@click.argument("limit", metavar="CACHE_LIMIT", type=int)
+def change_cache_limit(cache_path, limit):
+    """Change the maximum number of notebooks stored in the cache."""
+    db = JupyterCacheBase(cache_path)
+    db.change_cache_limit(limit)
+    click.secho("Cache limit changed!", fg="green")

--- a/jupyter_cache/cli/commands/cmd_config.py
+++ b/jupyter_cache/cli/commands/cmd_config.py
@@ -1,8 +1,8 @@
 import click
 
-from jupyter_cache.cache import JupyterCacheBase
 from jupyter_cache.cli.commands.cmd_main import jcache
 from jupyter_cache.cli import options
+from jupyter_cache.cli.utils import get_cache
 
 
 @jcache.group("config")
@@ -16,6 +16,6 @@ def cmnd_config():
 @click.argument("limit", metavar="CACHE_LIMIT", type=int)
 def change_cache_limit(cache_path, limit):
     """Change the maximum number of notebooks stored in the cache."""
-    db = JupyterCacheBase(cache_path)
+    db = get_cache(cache_path)
     db.change_cache_limit(limit)
     click.secho("Cache limit changed!", fg="green")

--- a/jupyter_cache/cli/commands/cmd_exec.py
+++ b/jupyter_cache/cli/commands/cmd_exec.py
@@ -21,7 +21,7 @@ click_log.basic_config(logger)
 @options.EXEC_ENTRYPOINT
 @options.CACHE_PATH
 def execute_nbs(cache_path, entry_point):
-    """Execute outdated notebooks."""
+    """Execute staged notebooks that are outdated."""
     from jupyter_cache.executors import load_executor
 
     db = JupyterCacheBase(cache_path)

--- a/jupyter_cache/cli/commands/cmd_exec.py
+++ b/jupyter_cache/cli/commands/cmd_exec.py
@@ -5,12 +5,7 @@ import click_log
 
 from jupyter_cache.cli.commands.cmd_main import jcache
 from jupyter_cache.cli import options
-from jupyter_cache.cache import JupyterCacheBase
-from jupyter_cache.base import (  # noqa: F401
-    CachingError,
-    RetrievalError,
-    NbValidityError,
-)
+from jupyter_cache.cli.utils import get_cache
 
 logger = logging.getLogger(__name__)
 click_log.basic_config(logger)
@@ -24,7 +19,7 @@ def execute_nbs(cache_path, entry_point):
     """Execute staged notebooks that are outdated."""
     from jupyter_cache.executors import load_executor
 
-    db = JupyterCacheBase(cache_path)
+    db = get_cache(cache_path)
     try:
         executor = load_executor("basic", db, logger=logger)
     except ImportError as error:

--- a/jupyter_cache/cli/commands/cmd_main.py
+++ b/jupyter_cache/cli/commands/cmd_main.py
@@ -8,8 +8,8 @@ from jupyter_cache.cli import options
     None, "-v", "--version", message="jupyter-cache version %(version)s"
 )
 @options.PRINT_CACHE_PATH
-# @options.AUTOCOMPLETE  # doesn't allow file path autocompletion
-def jcache(cache_path):
+@options.AUTOCOMPLETE
+def jcache(*args):
     """The command line interface of jupyter-cache."""
 
 

--- a/jupyter_cache/cli/commands/cmd_main.py
+++ b/jupyter_cache/cli/commands/cmd_main.py
@@ -11,3 +11,15 @@ from jupyter_cache.cli import options
 # @options.AUTOCOMPLETE  # doesn't allow file path autocompletion
 def jcache(cache_path):
     """The command line interface of jupyter-cache."""
+
+
+@jcache.command("clear")
+@options.CACHE_PATH
+def clear_cache(cache_path):
+    """Clear the cache completely."""
+    from jupyter_cache.cache import JupyterCacheBase
+
+    db = JupyterCacheBase(cache_path)
+    click.confirm("Are you sure you want to permanently clear the cache!?", abort=True)
+    db.clear_cache()
+    click.secho("Cache cleared!", fg="green")

--- a/jupyter_cache/cli/commands/cmd_main.py
+++ b/jupyter_cache/cli/commands/cmd_main.py
@@ -9,7 +9,7 @@ from jupyter_cache.cli import options
 )
 @options.PRINT_CACHE_PATH
 @options.AUTOCOMPLETE
-def jcache(*args):
+def jcache(*args, **kwargs):
     """The command line interface of jupyter-cache."""
 
 
@@ -17,7 +17,7 @@ def jcache(*args):
 @options.CACHE_PATH
 def clear_cache(cache_path):
     """Clear the cache completely."""
-    from jupyter_cache.cache import JupyterCacheBase
+    from jupyter_cache.cache.main import JupyterCacheBase
 
     db = JupyterCacheBase(cache_path)
     click.confirm("Are you sure you want to permanently clear the cache!?", abort=True)

--- a/jupyter_cache/cli/commands/cmd_stage.py
+++ b/jupyter_cache/cli/commands/cmd_stage.py
@@ -1,0 +1,114 @@
+import click
+import tabulate
+import yaml
+
+from jupyter_cache.cli.commands.cmd_main import jcache
+from jupyter_cache.cli import arguments, options
+from jupyter_cache.cli.utils import shorten_path
+from jupyter_cache.cache import JupyterCacheBase
+from jupyter_cache.base import (  # noqa: F401
+    CachingError,
+    RetrievalError,
+    NbValidityError,
+)
+
+
+@jcache.group("stage")
+def cmnd_stage():
+    """Commands for staging notebooks to be executed."""
+    pass
+
+
+@cmnd_stage.command("add-many")
+@arguments.NB_PATHS
+@options.CACHE_PATH
+def stage_nbs(cache_path, nbpaths):
+    """Stage notebook(s) for execution."""
+    db = JupyterCacheBase(cache_path)
+    for path in nbpaths:
+        # TODO deal with errors (print all at end? or option to ignore)
+        click.echo("Staging: {}".format(path))
+        db.stage_notebook_file(path)
+    click.secho("Success!", fg="green")
+
+
+@cmnd_stage.command("add-one")
+@arguments.ASSET_PATHS
+@options.NB_PATH
+@options.CACHE_PATH
+def stage_nb(cache_path, nbpath, asset_paths):
+    """Stage a notebook, with possible assets."""
+    db = JupyterCacheBase(cache_path)
+    db.stage_notebook_file(nbpath, asset_paths)
+    click.secho("Success!", fg="green")
+
+
+@cmnd_stage.command("remove")
+@arguments.NB_PATHS
+@options.CACHE_PATH
+@options.REMOVE_ALL
+def unstage_nbs(cache_path, nbpaths, remove_all):
+    """Unstage notebook(s) for execution."""
+    db = JupyterCacheBase(cache_path)
+    if remove_all:
+        nbpaths = [record.uri for record in db.list_staged_records()]
+    for path in nbpaths:
+        # TODO deal with errors (print all at end? or option to ignore)
+        click.echo("Unstaging: {}".format(path))
+        db.discard_staged_notebook(path)
+    click.secho("Success!", fg="green")
+
+
+def format_staged_record(record, cache_record, path_length, assets=True):
+    data = {
+        "ID": record.pk,
+        "URI": str(shorten_path(record.uri, path_length)),
+        "Created": record.created.isoformat(" ", "minutes"),
+    }
+    if assets:
+        data["Assets"] = len(record.assets)
+    if cache_record:
+        data["Cache ID"] = cache_record.pk
+    return data
+
+
+@cmnd_stage.command("list")
+@options.CACHE_PATH
+@click.option(
+    "--compare/--no-compare",
+    default=True,
+    show_default=True,
+    help="Compare to cached notebooks (to find cache ID).",
+)
+@options.PATH_LENGTH
+def list_staged(cache_path, compare, path_length):
+    """List notebooks staged for possible execution."""
+    db = JupyterCacheBase(cache_path)
+    records = db.list_staged_records()
+    if not records:
+        click.secho("No Staged Notebooks", fg="blue")
+    rows = []
+    for record in sorted(records, key=lambda r: r.created, reverse=True):
+        cache_record = None
+        if compare:
+            cache_record = db.get_cache_record_of_staged(record.uri)
+        rows.append(format_staged_record(record, cache_record, path_length))
+    click.echo(tabulate.tabulate(rows, headers="keys"))
+
+
+@cmnd_stage.command("show")
+@options.CACHE_PATH
+@arguments.PK
+def show_staged(cache_path, pk):
+    """Show details of a staged notebook."""
+    db = JupyterCacheBase(cache_path)
+    record = db.get_staged_record(pk)
+    cache_record = db.get_cache_record_of_staged(record.uri)
+    data = format_staged_record(record, cache_record, None, assets=False)
+    click.echo(yaml.safe_dump(data, sort_keys=False), nl=False)
+    if not record.assets:
+        click.echo("")
+        return
+    click.echo(f"Assets:")
+    for path in record.assets:
+        click.echo(f"- {path}")

--- a/jupyter_cache/cli/commands/cmd_stage.py
+++ b/jupyter_cache/cli/commands/cmd_stage.py
@@ -31,7 +31,7 @@ def stage_nbs(cache_path, nbpaths):
 @options.NB_PATH
 @options.CACHE_PATH
 def stage_nb(cache_path, nbpath, asset_paths):
-    """Stage a notebook, with possible assets."""
+    """Stage a notebook, with possible asset files."""
     db = get_cache(cache_path)
     db.stage_notebook_file(nbpath, asset_paths)
     click.secho("Success!", fg="green")

--- a/jupyter_cache/cli/options.py
+++ b/jupyter_cache/cli/options.py
@@ -4,7 +4,7 @@ import click
 
 def callback_autocomplete(ctx, param, value):
     if value and not ctx.resilient_parsing:
-        click.echo("Run this in the terminal for auto-completion:")
+        click.echo("Execute this in the terminal for auto-completion:")
         click.echo('eval "$(_JCACHE_COMPLETE=source jcache)"')
         ctx.exit()
 
@@ -12,7 +12,7 @@ def callback_autocomplete(ctx, param, value):
 AUTOCOMPLETE = click.option(
     "-a",
     "--autocomplete",
-    help="Print the terminal autocompletion command and exit.",
+    help="Print the autocompletion command and exit.",
     is_flag=True,
     expose_value=True,
     is_eager=True,

--- a/jupyter_cache/cli/options.py
+++ b/jupyter_cache/cli/options.py
@@ -94,7 +94,7 @@ VALIDATE_NB = click.option(
 )
 
 
-OVERWRITE_COMMIT = click.option(
+OVERWRITE_CACHED = click.option(
     "--overwrite/--no-overwrite",
     default=True,
     show_default=True,

--- a/jupyter_cache/cli/utils.py
+++ b/jupyter_cache/cli/utils.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+
+def shorten_path(file_path, length):
+    """Split the path into separate parts,
+    select the last 'length' elements and join them again
+    """
+    if length is None:
+        return Path(file_path)
+    return Path(*Path(file_path).parts[-length:])

--- a/jupyter_cache/cli/utils.py
+++ b/jupyter_cache/cli/utils.py
@@ -1,10 +1,16 @@
-from pathlib import Path
-
-
 def shorten_path(file_path, length):
     """Split the path into separate parts,
     select the last 'length' elements and join them again
     """
+    from pathlib import Path
+
     if length is None:
         return Path(file_path)
     return Path(*Path(file_path).parts[-length:])
+
+
+def get_cache(path):
+    # load lazily, to improve CLI speed
+    from jupyter_cache.cache.main import JupyterCacheBase
+
+    return JupyterCacheBase(path)

--- a/jupyter_cache/executors/__init__.py
+++ b/jupyter_cache/executors/__init__.py
@@ -1,1 +1,1 @@
-from .base import JupyterCacheAbstract, load_executor  # noqa: F401
+from .base import JupyterExecutorAbstract, load_executor  # noqa: F401

--- a/jupyter_cache/executors/base.py
+++ b/jupyter_cache/executors/base.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 from jupyter_cache.base import JupyterCacheAbstract
 
 # TODO abstact
-from jupyter_cache.cache.db import NbCommitRecord
+from jupyter_cache.cache.db import NbCacheRecord
 
 ENTRY_POINT_GROUP = "jupyter_executors"
 
@@ -33,7 +33,7 @@ class JupyterExecutorAbstract(ABC):
         return self._logger
 
     @abstractmethod
-    def run(self, uri_filter: Optional[List[str]] = None) -> List[NbCommitRecord]:
+    def run(self, uri_filter: Optional[List[str]] = None) -> List[NbCacheRecord]:
         """Run execution, stage successfully executed notebooks and return their URIs
 
         Parameters

--- a/jupyter_cache/executors/basic.py
+++ b/jupyter_cache/executors/basic.py
@@ -62,9 +62,9 @@ class JupyterExecutorBasic(JupyterExecutorAbstract):
                     data={"execution_seconds": timer.last_split},
                 )
                 try:
-                    self.cache.commit_notebook_bundle(final_bundle, overwrite=True)
+                    self.cache.cache_notebook_bundle(final_bundle, overwrite=True)
                 except Exception:
-                    self.logger.error("Failed Commit: {}".format(uri), exc_info=True)
+                    self.logger.error("Failed Caching: {}".format(uri), exc_info=True)
                     continue
 
                 self.logger.info("Success: {}".format(uri))
@@ -76,7 +76,7 @@ class JupyterExecutorBasic(JupyterExecutorAbstract):
         # TODO it would also be ideal to tag all notebooks
         # that were executed at the same time (just part of `data` or separate column?).
         # TODO maybe the status of success/failure could be stored on
-        # the stage record (commit_status=Enum('OK', 'FAILED', 'MISSING'))
+        # the stage record (cache_status=Enum('OK', 'FAILED', 'MISSING'))
         # also failed notebooks could be stored in the cache, which would be
         # accessed by stage pk (and would be deleted when removing the stage record)
         # see: https://python.quantecon.org/status.html

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     # note: nbdime could be made an extra
     install_requires=["attrs", "nbformat", "nbdime", "nbconvert", "sqlalchemy"],
     extras_require={
-        "cli": ["click", "click-log", "tabulate", "pyyaml"],
+        "cli": ["click", "click-completion", "click-log", "tabulate", "pyyaml"],
         "code_style": ["flake8<3.8.0,>=3.7.0", "black", "pre-commit==1.17.0"],
         "testing": ["coverage", "pytest>=3.6,<4", "pytest-cov", "pytest-regressions"],
     },

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -4,7 +4,7 @@ from textwrap import dedent
 import nbformat as nbf
 import pytest
 
-from jupyter_cache.cache import JupyterCacheBase
+from jupyter_cache.cache.main import JupyterCacheBase
 from jupyter_cache.base import NbValidityError
 
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -14,21 +14,21 @@ NB_PATH = os.path.join(os.path.realpath(os.path.dirname(__file__)), "notebooks")
 def test_basic_workflow(tmp_path):
     cache = JupyterCacheBase(str(tmp_path))
     with pytest.raises(NbValidityError):
-        cache.commit_notebook_file(path=os.path.join(NB_PATH, "basic.ipynb"))
-    cache.commit_notebook_file(
+        cache.cache_notebook_file(path=os.path.join(NB_PATH, "basic.ipynb"))
+    cache.cache_notebook_file(
         path=os.path.join(NB_PATH, "basic.ipynb"),
         uri="basic.ipynb",
         check_validity=False,
     )
-    assert cache.list_commit_records()[0].uri == "basic.ipynb"
-    pk = cache.match_commit_file(path=os.path.join(NB_PATH, "basic.ipynb")).pk
-    nb_bundle = cache.get_commit_bundle(pk)
+    assert cache.list_cache_records()[0].uri == "basic.ipynb"
+    pk = cache.match_cache_file(path=os.path.join(NB_PATH, "basic.ipynb")).pk
+    nb_bundle = cache.get_cache_bundle(pk)
     assert nb_bundle.nb.metadata["kernelspec"] == {
         "display_name": "Python 3",
         "language": "python",
         "name": "python3",
     }
-    assert set(nb_bundle.commit.to_dict().keys()) == {
+    assert set(nb_bundle.record.to_dict().keys()) == {
         "pk",
         "hashkey",
         "uri",
@@ -37,14 +37,14 @@ def test_basic_workflow(tmp_path):
         "accessed",
         "description",
     }
-    # assert cache.get_commit_codecell(pk, 0).source == "a=1\nprint(a)"
+    # assert cache.get_cache_codecell(pk, 0).source == "a=1\nprint(a)"
 
     path = os.path.join(NB_PATH, "basic_failing.ipynb")
-    diff = cache.diff_nbfile_with_commit(pk, path, as_str=True, use_color=False)
+    diff = cache.diff_nbfile_with_cache(pk, path, as_str=True, use_color=False)
     assert diff == dedent(
         f"""\
         nbdiff
-        --- committed pk=1
+        --- cached pk=1
         +++ other: {path}
         ## inserted before nb/cells/0:
         +  code cell:
@@ -66,10 +66,10 @@ def test_basic_workflow(tmp_path):
 
         """
     )
-    cache.remove_commit(pk)
-    assert cache.list_commit_records() == []
+    cache.remove_cache(pk)
+    assert cache.list_cache_records() == []
 
-    cache.commit_notebook_file(
+    cache.cache_notebook_file(
         path=os.path.join(NB_PATH, "basic.ipynb"),
         uri="basic.ipynb",
         check_validity=False,
@@ -91,12 +91,12 @@ def test_basic_workflow(tmp_path):
     assert bundle.nb.metadata
 
     cache.clear_cache()
-    assert cache.list_commit_records() == []
+    assert cache.list_cache_records() == []
 
 
 def test_merge_match_into_notebook(tmp_path):
     cache = JupyterCacheBase(str(tmp_path))
-    cache.commit_notebook_file(
+    cache.cache_notebook_file(
         path=os.path.join(NB_PATH, "basic.ipynb"), check_validity=False
     )
     nb = nbf.read(os.path.join(NB_PATH, "basic_unrun.ipynb"), 4)
@@ -113,19 +113,19 @@ def test_merge_match_into_notebook(tmp_path):
 def test_artifacts(tmp_path):
     cache = JupyterCacheBase(str(tmp_path))
     with pytest.raises(IOError):
-        cache.commit_notebook_file(
+        cache.cache_notebook_file(
             path=os.path.join(NB_PATH, "basic.ipynb"),
             uri="basic.ipynb",
             artifacts=(os.path.join(NB_PATH),),
             check_validity=False,
         )
-    cache.commit_notebook_file(
+    cache.cache_notebook_file(
         path=os.path.join(NB_PATH, "basic.ipynb"),
         uri="basic.ipynb",
         artifacts=(os.path.join(NB_PATH, "artifact_folder", "artifact.txt"),),
         check_validity=False,
     )
-    hashkey = cache.get_commit_record(1).hashkey
+    hashkey = cache.get_cache_record(1).hashkey
     assert {
         str(p.relative_to(tmp_path)) for p in tmp_path.glob("**/*") if p.is_file()
     } == {
@@ -134,7 +134,7 @@ def test_artifacts(tmp_path):
         f"executed/{hashkey}/artifacts/artifact_folder/artifact.txt",
     }
 
-    bundle = cache.get_commit_bundle(1)
+    bundle = cache.get_cache_bundle(1)
     assert {str(p) for p in bundle.artifacts.relative_paths} == {
         "artifact_folder/artifact.txt"
     }
@@ -142,7 +142,7 @@ def test_artifacts(tmp_path):
     text = list(h.read().decode() for r, h in bundle.artifacts)[0]
     assert text.rstrip() == "An artifact"
 
-    with cache.commit_artefacts_temppath(1) as path:
+    with cache.cache_artefacts_temppath(1) as path:
         assert path.joinpath("artifact_folder").exists()
 
 
@@ -161,8 +161,8 @@ def test_execution(tmp_path):
         os.path.join(NB_PATH, "basic_unrun.ipynb"),
         os.path.join(NB_PATH, "external_output.ipynb"),
     ]
-    assert len(db.list_commit_records()) == 2
-    bundle = db.get_commit_bundle(1)
+    assert len(db.list_cache_records()) == 2
+    bundle = db.get_cache_bundle(1)
     assert bundle.nb.cells[0] == {
         "cell_type": "code",
         "execution_count": 1,
@@ -170,8 +170,8 @@ def test_execution(tmp_path):
         "outputs": [{"name": "stdout", "output_type": "stream", "text": "1\n"}],
         "source": "a=1\nprint(a)",
     }
-    assert "execution_seconds" in bundle.commit.data
-    with db.commit_artefacts_temppath(2) as path:
+    assert "execution_seconds" in bundle.record.data
+    with db.cache_artefacts_temppath(2) as path:
         paths = [str(p.relative_to(path)) for p in path.glob("**/*") if p.is_file()]
         assert paths == ["artifact.txt"]
         assert path.joinpath("artifact.txt").read_text() == "hi"

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -146,6 +146,9 @@ def test_artifacts(tmp_path):
         assert path.joinpath("artifact_folder").exists()
 
 
+# jupyter_client/session.py:371: DeprecationWarning:
+# Session._key_changed is deprecated in traitlets: use @observe and @unobserve instead
+@pytest.mark.filterwarnings("ignore")
 def test_execution(tmp_path):
     from jupyter_cache.executors import load_executor
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,32 +25,32 @@ def test_clear_cache(tmp_path):
     assert "Cache cleared!" in result.output.strip(), result.output
 
 
-def test_list_commits(tmp_path):
+def test_list_caches(tmp_path):
     db = JupyterCacheBase(str(tmp_path))
-    db.commit_notebook_file(
+    db.cache_notebook_file(
         path=os.path.join(NB_PATH, "basic.ipynb"),
         uri="basic.ipynb",
         check_validity=False,
     )
     runner = CliRunner()
-    result = runner.invoke(cmd_cache.list_commits, ["-p", tmp_path])
+    result = runner.invoke(cmd_cache.list_caches, ["-p", tmp_path])
     assert result.exception is None, result.output
     assert result.exit_code == 0, result.output
     assert "basic.ipynb" in result.output.strip(), result.output
 
 
-def test_commit_with_artifact(tmp_path):
+def test_cache_with_artifact(tmp_path):
     JupyterCacheBase(str(tmp_path))
     nb_path = os.path.join(NB_PATH, "basic.ipynb")
     a_path = os.path.join(NB_PATH, "artifact_folder", "artifact.txt")
     runner = CliRunner()
     result = runner.invoke(
-        cmd_cache.commit_nb, ["-p", tmp_path, "--no-validate", "-nb", nb_path, a_path]
+        cmd_cache.cache_nb, ["-p", tmp_path, "--no-validate", "-nb", nb_path, a_path]
     )
     assert result.exception is None, result.output
     assert result.exit_code == 0, result.output
     assert "basic.ipynb" in result.output.strip(), result.output
-    result = runner.invoke(cmd_cache.show_commit, ["-p", tmp_path, "1"])
+    result = runner.invoke(cmd_cache.show_cache, ["-p", tmp_path, "1"])
     assert result.exception is None, result.output
     assert result.exit_code == 0, result.output
     assert "- artifact_folder/artifact.txt" in result.output.strip(), result.output
@@ -62,40 +62,38 @@ def test_commit_with_artifact(tmp_path):
     assert "An artifact" in result.output.strip(), result.output
 
 
-def test_commit_nbs(tmp_path):
+def test_cache_nbs(tmp_path):
     db = JupyterCacheBase(str(tmp_path))
     path = os.path.join(NB_PATH, "basic.ipynb")
     runner = CliRunner()
-    result = runner.invoke(
-        cmd_cache.commit_nbs, ["-p", tmp_path, "--no-validate", path]
-    )
+    result = runner.invoke(cmd_cache.cache_nbs, ["-p", tmp_path, "--no-validate", path])
     assert result.exception is None, result.output
     assert result.exit_code == 0, result.output
     assert "basic.ipynb" in result.output.strip(), result.output
-    assert db.list_commit_records()[0].uri == path
+    assert db.list_cache_records()[0].uri == path
 
 
-def test_remove_commits(tmp_path):
+def test_remove_caches(tmp_path):
     db = JupyterCacheBase(str(tmp_path))
-    db.commit_notebook_file(
+    db.cache_notebook_file(
         path=os.path.join(NB_PATH, "basic.ipynb"),
         uri="basic.ipynb",
         check_validity=False,
     )
     runner = CliRunner()
-    result = runner.invoke(cmd_cache.remove_commits, ["-p", tmp_path, "1"])
+    result = runner.invoke(cmd_cache.remove_caches, ["-p", tmp_path, "1"])
     assert result.exception is None, result.output
     assert result.exit_code == 0, result.output
     assert "Success" in result.output.strip(), result.output
-    assert db.list_commit_records() == []
+    assert db.list_cache_records() == []
 
 
 def test_diff_nbs(tmp_path):
     db = JupyterCacheBase(str(tmp_path))
     path = os.path.join(NB_PATH, "basic.ipynb")
     path2 = os.path.join(NB_PATH, "basic_failing.ipynb")
-    db.commit_notebook_file(path, check_validity=False)
-    # nb_bundle = db.get_commit_bundle(1)
+    db.cache_notebook_file(path, check_validity=False)
+    # nb_bundle = db.get_cache_bundle(1)
     # nb_bundle.nb.cells[0].source = "# New Title"
     # db.stage_notebook_bundle(nb_bundle)
 
@@ -105,7 +103,7 @@ def test_diff_nbs(tmp_path):
     assert result.exit_code == 0, result.output
     print(result.output.splitlines()[2:])
     assert result.output.splitlines()[1:] == [
-        "--- committed pk=1",
+        "--- cached pk=1",
         f"+++ other: {path2}",
         "## inserted before nb/cells/0:",
         "+  code cell:",
@@ -155,7 +153,7 @@ def test_unstage_nbs(tmp_path):
 
 def test_list_staged(tmp_path):
     db = JupyterCacheBase(str(tmp_path))
-    db.commit_notebook_file(
+    db.cache_notebook_file(
         path=os.path.join(NB_PATH, "basic.ipynb"), check_validity=False
     )
     db.stage_notebook_file(path=os.path.join(NB_PATH, "basic.ipynb"))
@@ -170,7 +168,7 @@ def test_list_staged(tmp_path):
 
 def test_show_staged(tmp_path):
     db = JupyterCacheBase(str(tmp_path))
-    db.commit_notebook_file(
+    db.cache_notebook_file(
         path=os.path.join(NB_PATH, "basic.ipynb"), check_validity=False
     )
     db.stage_notebook_file(path=os.path.join(NB_PATH, "basic.ipynb"))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,7 +3,7 @@ import os
 from click.testing import CliRunner
 
 from jupyter_cache.cache import JupyterCacheBase
-from jupyter_cache.cli.commands import cmd_main, cmd_cache
+from jupyter_cache.cli.commands import cmd_main, cmd_cache, cmd_stage
 
 NB_PATH = os.path.join(os.path.realpath(os.path.dirname(__file__)), "notebooks")
 
@@ -19,7 +19,7 @@ def test_base():
 def test_clear_cache(tmp_path):
     JupyterCacheBase(str(tmp_path))
     runner = CliRunner()
-    result = runner.invoke(cmd_cache.clear_cache, ["-p", tmp_path], input="y")
+    result = runner.invoke(cmd_main.clear_cache, ["-p", tmp_path], input="y")
     assert result.exception is None, result.output
     assert result.exit_code == 0, result.output
     assert "Cache cleared!" in result.output.strip(), result.output
@@ -132,7 +132,7 @@ def test_stage_nbs(tmp_path):
     db = JupyterCacheBase(str(tmp_path))
     path = os.path.join(NB_PATH, "basic.ipynb")
     runner = CliRunner()
-    result = runner.invoke(cmd_cache.stage_nbs, ["-p", tmp_path, path])
+    result = runner.invoke(cmd_stage.stage_nbs, ["-p", tmp_path, path])
     assert result.exception is None, result.output
     assert result.exit_code == 0, result.output
     assert "basic.ipynb" in result.output.strip(), result.output
@@ -143,8 +143,8 @@ def test_unstage_nbs(tmp_path):
     db = JupyterCacheBase(str(tmp_path))
     path = os.path.join(NB_PATH, "basic.ipynb")
     runner = CliRunner()
-    result = runner.invoke(cmd_cache.stage_nbs, ["-p", tmp_path, path])
-    result = runner.invoke(cmd_cache.unstage_nbs, ["-p", tmp_path, path])
+    result = runner.invoke(cmd_stage.stage_nbs, ["-p", tmp_path, path])
+    result = runner.invoke(cmd_stage.unstage_nbs, ["-p", tmp_path, path])
     assert result.exception is None, result.output
     assert result.exit_code == 0, result.output
     assert "basic.ipynb" in result.output.strip(), result.output
@@ -160,7 +160,7 @@ def test_list_staged(tmp_path):
     db.stage_notebook_file(path=os.path.join(NB_PATH, "basic_failing.ipynb"))
 
     runner = CliRunner()
-    result = runner.invoke(cmd_cache.list_staged, ["-p", tmp_path])
+    result = runner.invoke(cmd_stage.list_staged, ["-p", tmp_path])
     assert result.exception is None, result.output
     assert result.exit_code == 0, result.output
     assert "basic.ipynb" in result.output.strip(), result.output
@@ -174,7 +174,7 @@ def test_show_staged(tmp_path):
     db.stage_notebook_file(path=os.path.join(NB_PATH, "basic.ipynb"))
 
     runner = CliRunner()
-    result = runner.invoke(cmd_cache.show_staged, ["-p", tmp_path, "1"])
+    result = runner.invoke(cmd_stage.show_staged, ["-p", tmp_path, "1"])
     assert result.exception is None, result.output
     assert result.exit_code == 0, result.output
     assert "basic.ipynb" in result.output.strip(), result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -144,7 +144,7 @@ def test_unstage_nbs(tmp_path):
     path = os.path.join(NB_PATH, "basic.ipynb")
     runner = CliRunner()
     result = runner.invoke(cmd_stage.stage_nbs, ["-p", tmp_path, path])
-    result = runner.invoke(cmd_stage.unstage_nbs, ["-p", tmp_path, path])
+    result = runner.invoke(cmd_stage.unstage_nbs_uri, ["-p", tmp_path, path])
     assert result.exception is None, result.output
     assert result.exit_code == 0, result.output
     assert "basic.ipynb" in result.output.strip(), result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,7 +2,7 @@ import os
 
 from click.testing import CliRunner
 
-from jupyter_cache.cache import JupyterCacheBase
+from jupyter_cache.cache.main import JupyterCacheBase
 from jupyter_cache.cli.commands import cmd_main, cmd_cache, cmd_stage
 
 NB_PATH = os.path.join(os.path.realpath(os.path.dirname(__file__)), "notebooks")

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,6 +1,6 @@
 import pytest
 
-from jupyter_cache.cache.db import create_db, NbCommitRecord, Setting
+from jupyter_cache.cache.db import create_db, NbCacheRecord, Setting
 
 
 def test_setting(tmp_path):
@@ -12,10 +12,10 @@ def test_setting(tmp_path):
 
 def test_nb_record(tmp_path):
     db = create_db(tmp_path)
-    bundle = NbCommitRecord.create_record("a", "b", db)
+    bundle = NbCacheRecord.create_record("a", "b", db)
     assert bundle.hashkey == "b"
     with pytest.raises(ValueError):
-        NbCommitRecord.create_record("a", "b", db)
-    NbCommitRecord.create_record("a", "c", db, data="a")
-    assert NbCommitRecord.record_from_hashkey("b", db).uri == "a"
-    assert {b.hashkey for b in NbCommitRecord.records_from_uri("a", db)} == {"b", "c"}
+        NbCacheRecord.create_record("a", "b", db)
+    NbCacheRecord.create_record("a", "c", db, data="a")
+    assert NbCacheRecord.record_from_hashkey("b", db).uri == "a"
+    assert {b.hashkey for b in NbCacheRecord.records_from_uri("a", db)} == {"b", "c"}


### PR DESCRIPTION
This PR requires #17 to be merged first.

The PR relates to discussion in #16.

Read the REAMDE.md for details on the full CLI change. But basically commands have been renamed and moved into separate top-level groups:

```console
$ jcache
Usage: jcache [OPTIONS] COMMAND [ARGS]...

  The command line interface of jupyter-cache.

Options:
  -v, --version       Show the version and exit.
  -p, --cache-path    Print the current cache path and exit.
  -a, --autocomplete  Print the autocompletion command and exit.
  -h, --help          Show this message and exit.

Commands:
  cache    Commands for adding to and inspecting the cache.
  clear    Clear the cache completely.
  config   Commands for configuring the cache.
  execute  Execute staged notebooks that are outdated.
  stage    Commands for staging notebooks to be executed.
```

```console
$ jcache cache
Usage: jcache cache [OPTIONS] COMMAND [ARGS]...

  Commands for adding to and inspecting the cache.

Options:
  -h, --help  Show this message and exit.

Commands:
  add-many      Cache notebook(s) that have already been executed.
  add-one       Cache a notebook, with possible artefact files.
  cat-artifact  Print the contents of a cached artefact.
  diff-nb       Print a diff of a notebook to one stored in the cache.
  list          List cached notebook records in the cache.
  remove        Remove notebooks stored in the cache.
  show          Show details of a cached notebook in the cache.
```

```console
$ jcache stage 
Usage: jcache stage [OPTIONS] COMMAND [ARGS]...

  Commands for staging notebooks to be executed.

Options:
  -h, --help  Show this message and exit.

Commands:
  add-many     Stage notebook(s) for execution.
  add-one      Stage a notebook, with possible asset files.
  list         List notebooks staged for possible execution.
  remove-ids   Un-stage notebook(s), by ID.
  remove-uris  Un-stage notebook(s), by URI.
  show         Show details of a staged notebook.
```

Also I have added click-completions as a dependency, which can be activated in the terminal by executing `eval "$(_JCACHE_COMPLETE=source jcache)"`.